### PR TITLE
Fix Lease Messages in /res limits

### DIFF
--- a/src/com/bekvon/bukkit/residence/permissions/PermissionGroup.java
+++ b/src/com/bekvon/bukkit/residence/permissions/PermissionGroup.java
@@ -431,9 +431,9 @@ public class PermissionGroup {
 	}
 	Residence.msg(player, lm.Limits_Flag, group.flagPerms.listFlags());
 	if (Residence.getConfigManager().useLeases()) {
-	    Residence.msg(player, lm.Limits_Flag, group.maxLeaseTime);
-	    Residence.msg(player, lm.Limits_Flag, group.leaseGiveTime);
-	    Residence.msg(player, lm.Limits_Flag, group.renewcostperarea);
+	    Residence.msg(player, lm.Limits_MaxDays, group.maxLeaseTime);
+	    Residence.msg(player, lm.Limits_LeaseTime, group.leaseGiveTime);
+	    Residence.msg(player, lm.Limits_RenewCost, group.renewcostperarea);
 	}
 	Residence.msg(player, lm.General_Separator);
     }


### PR DESCRIPTION
On current Residence builds with the Lease system enabled, all three sections of `/res limits` related to lease say "Flag Permissions:".

The data given is correct and in the same order as Bekvon's repository, however players don't know what these values are supposed to be and, thus, think it's not listed.

The strings for lease information appear to exist in LocaleManager and in other language files, so it looks to be a basic copy/paste error in replacing hardcoded strings with it.

This should fix the issue and give lease information with the correct labels.