### PR TITLE
SlimeFun protection repair

### DIFF
--- a/src/com/bekvon/bukkit/residence/slimeFun/SlimeFunResidenceModule.java
+++ b/src/com/bekvon/bukkit/residence/slimeFun/SlimeFunResidenceModule.java
@@ -38,7 +38,7 @@ public class SlimeFunResidenceModule implements ProtectionModule {
 			return false;
 
 		switch (action) {
-			case ACCESS_INVENTORIES:
+			case INTERACT_BLOCK:
 				ClaimedResidence res = residence.getResidenceManager().getByLoc(loc);
 				if (res != null) {
 					boolean allow = res.getPermissions().playerHas(new ResidencePlayer(op), Flags.container, false);


### PR DESCRIPTION
Hi,
few days ago SlimeFun devs drop out new version and replaced ACCESS_INVENTORIES ProtectableAction with INTERACT_BLOCK. ACCESS_INVENTORIES is now deprecated and not functional, so i made simple fix.