### PR TITLE
Fix #354, just check the block location permission

### DIFF
--- a/src/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
+++ b/src/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
@@ -995,7 +995,7 @@ public class ResidenceEntityListener implements Listener {
 	if (ent.getType() != EntityType.WITHER)
 	    return;
 
-	if (!plugin.getPermsByLoc(ent.getLocation()).has(Flags.witherdestruction, FlagCombo.OnlyFalse))
+	if (!plugin.getPermsByLoc(event.getBlock().getLocation()).has(Flags.witherdestruction, FlagCombo.OnlyFalse))
 	    return;
 
 	event.setCancelled(true);


### PR DESCRIPTION
When a block was changed, plugin should check the block location permissions rather than entity location permissions, otherwise wither outside the residence could break the block in residence.