### PR TITLE
[Fix] Chest protection on residence edge

### DIFF
--- a/src/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
+++ b/src/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
@@ -444,25 +444,25 @@ public class ResidenceBlockListener implements Listener {
         Block b = block.getLocation().clone().add(0, 0, -1).getBlock();
         if (b.getType() == block.getType()) {
             res = plugin.getResidenceManager().getByLoc(b.getLocation());
-            if (res != null && !res.equals(orRes))
+            if (res != null && !res.equals(orRes) && !res.isTrusted(player))
                 cancel = true;
         }
         b = block.getLocation().clone().add(0, 0, 1).getBlock();
         if (b.getType() == block.getType()) {
             res = plugin.getResidenceManager().getByLoc(b.getLocation());
-            if (res != null && !res.equals(orRes))
+            if (res != null && !res.equals(orRes) && !res.isTrusted(player))
                 cancel = true;
         }
         b = block.getLocation().clone().add(1, 0, 0).getBlock();
         if (b.getType() == block.getType()) {
             res = plugin.getResidenceManager().getByLoc(b.getLocation());
-            if (res != null && !res.equals(orRes))
+            if (res != null && !res.equals(orRes) && !res.isTrusted(player))
                 cancel = true;
         }
         b = block.getLocation().clone().add(-1, 0, 0).getBlock();
         if (b.getType() == block.getType()) {
             res = plugin.getResidenceManager().getByLoc(b.getLocation());
-            if (res != null && !res.equals(orRes))
+            if (res != null && !res.equals(orRes) && !res.isTrusted(player))
                 cancel = true;
         }
 


### PR DESCRIPTION
Fixes an issue, where in two residences where a player is trusted, it's not possible to place a **double** chest on the edge.