### PR TITLE
Fix lease expiration time overflow

### DIFF
--- a/src/com/bekvon/bukkit/residence/protection/LeaseManager.java
+++ b/src/com/bekvon/bukkit/residence/protection/LeaseManager.java
@@ -184,7 +184,7 @@ public class LeaseManager {
 	long get = res.getLeaseExpireTime();
 	if (get <= System.currentTimeMillis())
 	    return 0;
-	return msToDays((int) (get - System.currentTimeMillis()));
+	return msToDays(get - System.currentTimeMillis());
     }
 
     public void doExpirations() {


### PR DESCRIPTION
When lease expire time minus current time over 2147483647 will return wrong value. (about 21 days)