### PR TITLE
Fix #1279 ,Expand the detection range for animals to board a boat.

### DIFF
--- a/src/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener1_21.java
+++ b/src/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener1_21.java
@@ -65,7 +65,7 @@ public class ResidencePlayerListener1_21 implements Listener {
             return;
 
         Player closest = null;
-        double dist = 16D;
+        double dist = 32D;
 
         for (Player player : res.getPlayersInResidence()) {
 
@@ -82,7 +82,7 @@ public class ResidencePlayerListener1_21 implements Listener {
 
         if (res.getPermissions().playerHas(closest, Flags.leash, FlagCombo.OnlyFalse)) {
 
-            Long time = boats.computeIfAbsent(entity.getUniqueId(), k -> 0L);
+            Long time = boats.computeIfAbsent(closest.getUniqueId(), k -> 0L);
 
             if (time + 1000L < System.currentTimeMillis()) {
                 boats.put(closest.getUniqueId(), System.currentTimeMillis());


### PR DESCRIPTION
Fix https://github.com/Zrips/Residence/issues/1279
Because the lead pulling distance for the newly added mob "happy_ghast" in version 1.21.6 is 16, the detection range has been increased to 32 to allow for some redundancy.