### PR TITLE
Add exemption check for ResAdmin when destroying Vehicle

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
@@ -80,6 +80,9 @@ public class ResidenceListener1_14 implements Listener {
 
         Entity attacker = event.getAttacker();
         if (attacker instanceof Player) {
+            if (ResAdmin.isResAdmin((Player) attacker)) {
+                return;
+            }
             if (!FlagPermissions.has(event.getVehicle().getLocation(), (Player) attacker, Flags.vehicledestroy, FlagCombo.OnlyFalse))
                 return;
         } else {


### PR DESCRIPTION
Fixes the issue where ResAdmin cannot destroy vehicles within a player's Residence.