### PR TITLE
Fix command res list NPE

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/commands/list.java
+++ b/src/main/java/com/bekvon/bukkit/residence/commands/list.java
@@ -46,7 +46,7 @@ public class list implements cmd {
 
             if (world == null) {
                 World tempW = CMIWorld.getWorld(args[i]);
-                if (tempW.getName().equalsIgnoreCase(args[i])) {
+                if (tempW != null && tempW.getName().equalsIgnoreCase(args[i])) {
                     world = tempW;
                     continue;
                 }
@@ -55,8 +55,15 @@ public class list implements cmd {
             target = args[i];
         }
 
-        if (target != null && !sender.getName().equalsIgnoreCase(target) && !ResPerm.command_$1_others.hasPermission(sender, this.getClass().getSimpleName()))
+        if (target == null) {
+            target = sender.getName();
+        }
+
+        if (target != null && !sender.getName().equalsIgnoreCase(target) &&
+            !ResPerm.command_$1_others.hasPermission(sender, this.getClass().getSimpleName())) {
+            lm.General_NoCmdPermission.sendMessage(sender);
             return true;
+        }
 
         UUID uuid = ResidencePlayer.getUUID(target);
 


### PR DESCRIPTION
/res list [non-existent player]
/res list PlayerName [non-existent world]
will trigger NPE.
This PR fixes this situation.
​
​It also fixes the issue where, since version 6.0, players entering only `/res list` would not point to their own residence list.