### PR TITLE
Simplify the copper flag logic, copper_golem_statue interaction check

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_17.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_17.java
@@ -96,7 +96,7 @@ public class ResidenceListener1_17 implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerChangeCopper(EntityChangeBlockEvent event) {
 
         Block block = event.getBlock();


### PR DESCRIPTION
After simplification, the behavior remains consistent with the previous version, and a problem has been fixed: when Residence allows opening doors, players holding an axe or honeycomb can now open certain types of copper doors and copper trapdoors (which they couldn’t before).

The copper_golem_statue added in version 1.21.9+ can be interacted with to change between 4 poses. This PR, after testing, has also added protection checks for changing the poses of the **copper_golem_statue**.

The problem is shown as follows and has been resolved.


https://github.com/user-attachments/assets/59829f16-bb85-4b6a-b4e9-2f194a3a2e42


https://github.com/user-attachments/assets/aa1a7431-0b6b-4bfa-81ae-45c95867150f


1. Pre-Simplification Issue
Previously, the Copper Flag had a protection limitation: it could not fully safeguard all unoxidized waxed_copper-type blocks, leaving their states vulnerable to unintended modifications.

2. Post-Simplification Effect
Currently, the Copper Flag has addressed the above limitation—it can correctly cover and protect all copper-type blocks from unauthorized state changes.

3. Key Note
It should be noted that the protection logic of some Place Flags in Residence already includes restrictions on "copper block state modifications". Therefore, in most cases, Place Flags will still influence whether copper block states can be altered.
This round of logic simplification does not modify the above-mentioned "Place Flag-related logic". That specific part remains consistent with the original version and has not been altered.

ps: Associate this PR https://github.com/Zrips/CMILib/pull/80