### PR TITLE
Fix zombies breaking the Residence door, Leash flag should not override the boat riding action

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.UUID;
 
 import org.bukkit.Location;
+import org.bukkit.entity.Boat;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -11,6 +12,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.potion.PotionEffectType;
@@ -118,5 +120,37 @@ public class ResidenceListener1_21 implements Listener {
 
         // Removing weaving effect on death as there is no other way to properly handle this effect inside residence
         ent.removePotionEffect(PotionEffectType.WEAVING);
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onFenceLeashInteract(PlayerInteractEntityEvent event) {
+
+        // Disabling listener if flag disabled globally
+        if (!Flags.leash.isGlobalyEnabled())
+            return;
+
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(event.getRightClicked().getWorld()))
+            return;
+        Player player = event.getPlayer();
+
+        Entity entity = event.getRightClicked();
+
+        if (!(entity instanceof Boat))
+            return;
+
+        if (ResAdmin.isResAdmin(player))
+            return;
+
+        ClaimedResidence res = plugin.getResidenceManager().getByLoc(entity.getLocation());
+
+        if (res == null)
+            return;
+
+        if (res.getPermissions().playerHas(player, Flags.leash, FlagCombo.OnlyFalse)) {
+            lm.Residence_FlagDeny.sendMessage(player, Flags.leash, res.getName());
+            event.setCancelled(true);
+            player.updateInventory();
+        }
     }
 }


### PR DESCRIPTION
In Difficulty Hard, you don’t have to worry about various zombies destroying the Residence wooden doors and copper doors even if you AFK for a long time.
<img width="1920" height="1080" alt="All_Doors" src="https://github.com/user-attachments/assets/9505e006-64af-41de-852f-be5bf415cf28" />

Use **PlayerUnleashEntityEvent** to fix an exploit that allows forced removal of the leash.

Now, when Global Leash Flag set false, it can also correctly prevent players from using Leash Interact.