### PR TITLE
Avoid unnecessary repeated checks

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
@@ -230,6 +230,7 @@ public class ResidenceListener1_13 implements Listener {
         // Easier future addition
         } else if (isPlate) {
             targetFlag = Flags.pressure;
+
         }
 
         // Only get projectile player source
@@ -256,6 +257,7 @@ public class ResidenceListener1_13 implements Listener {
 
                 event.setCancelled(true);
                 return;
+
             }
 
         // Entity not player source


### PR DESCRIPTION
return after the event is cancelled, more readable