### PR TITLE
Register the event only on Paper servers of version 1.21.9 and above

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/Residence.java
+++ b/src/main/java/com/bekvon/bukkit/residence/Residence.java
@@ -77,6 +77,7 @@ import com.bekvon.bukkit.residence.listeners.ResidenceListener1_20;
 import com.bekvon.bukkit.residence.listeners.ResidenceListener1_21;
 import com.bekvon.bukkit.residence.listeners.ResidenceListener1_21_8_Paper;
 import com.bekvon.bukkit.residence.listeners.ResidenceListener1_21_8_Spigot;
+import com.bekvon.bukkit.residence.listeners.ResidenceListener1_21_9_Paper;
 import com.bekvon.bukkit.residence.listeners.ResidencePlayerListener;
 import com.bekvon.bukkit.residence.permissions.PermissionManager;
 import com.bekvon.bukkit.residence.persistance.YMLSaveHelper;
@@ -635,6 +636,11 @@ public class Residence extends JavaPlugin {
                         pm.registerEvents(new ResidenceListener1_21_8_Paper(this), this);
                     else
                         pm.registerEvents(new ResidenceListener1_21_8_Spigot(this), this);
+                }
+
+                if (Version.isCurrentEqualOrHigher(Version.v1_21_R6)) {
+                    if (Version.isPaperBranch())
+                        pm.registerEvents(new ResidenceListener1_21_9_Paper(this), this);
                 }
 
                 plistener = new ResidencePlayerListener(this);

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_8_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_8_Paper.java
@@ -5,7 +5,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 import com.bekvon.bukkit.residence.Residence;
@@ -14,10 +13,7 @@ import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 import com.bekvon.bukkit.residence.utils.Utils;
 
-import net.Zrips.CMILib.Entities.CMIEntityType;
-
 import io.papermc.paper.event.entity.EntityPushedByEntityAttackEvent;
-import io.papermc.paper.event.entity.ItemTransportingEntityValidateTargetEvent;
 
 public class ResidenceListener1_21_8_Paper implements Listener {
 
@@ -66,27 +62,5 @@ public class ResidenceListener1_21_8_Paper implements Listener {
                 return true;
         }
         return false;
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onCopperGolemInteract(ItemTransportingEntityValidateTargetEvent event) {
-
-        Entity entity = event.getEntity();
-        if (entity == null)
-            return;
-
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
-
-        if (CMIEntityType.get(entity) != CMIEntityType.COPPER_GOLEM)
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
-        if (perms.has(Flags.golemopenchest, perms.has(Flags.container, true)))
-            return;
-
-        event.setAllowed(false);
-
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_9_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_9_Paper.java
@@ -1,0 +1,45 @@
+package com.bekvon.bukkit.residence.listeners;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import com.bekvon.bukkit.residence.Residence;
+import com.bekvon.bukkit.residence.containers.Flags;
+import com.bekvon.bukkit.residence.protection.FlagPermissions;
+
+import net.Zrips.CMILib.Entities.CMIEntityType;
+
+import io.papermc.paper.event.entity.ItemTransportingEntityValidateTargetEvent;
+
+public class ResidenceListener1_21_9_Paper implements Listener {
+
+    private Residence plugin;
+
+    public ResidenceListener1_21_9_Paper(Residence plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onCopperGolemInteract(ItemTransportingEntityValidateTargetEvent event) {
+
+        Entity entity = event.getEntity();
+        if (entity == null)
+            return;
+
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(entity.getWorld()))
+            return;
+
+        if (CMIEntityType.get(entity) != CMIEntityType.COPPER_GOLEM)
+            return;
+
+        FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
+        if (perms.has(Flags.golemopenchest, perms.has(Flags.container, true)))
+            return;
+
+        event.setAllowed(false);
+
+    }
+}


### PR DESCRIPTION
This message will appear once in the console only when starting Paper 1.21.8 with Residence 6.0.1.0. It does not affect normal operation, but it can be resolved.

> [04:54:08 ERROR]: [Residence] Failed to register events for class com.bekvon.bukkit.residence.listeners.ResidenceListener1_21_8_Paper because io/papermc/paper/event/entity/ItemTransportingEntityValidateTargetEvent does not exist.

I'm always careless sometimes. :(