### PR TITLE
Make Boat and Minecart no longer immune to damage from Lava and Cactus

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
@@ -205,7 +205,7 @@ public class ResidenceListener1_13 implements Listener {
         Block block = event.getBlock();
         if (block == null)
             return;
-
+        // disabling event on world
         if (plugin.isDisabledWorldListener(block.getWorld()))
             return;
 
@@ -223,16 +223,6 @@ public class ResidenceListener1_13 implements Listener {
         if (!isButton && !isPlate)
             return;
 
-        Flags targetFlag = null;
-        if (isButton) {
-            targetFlag = Flags.button;
-
-        // Easier future addition
-        } else if (isPlate) {
-            targetFlag = Flags.pressure;
-
-        }
-
         // Only get projectile player source
         Player player = Utils.potentialProjectileToPlayer(entity);
         if (player != null) {
@@ -244,17 +234,15 @@ public class ResidenceListener1_13 implements Listener {
             boolean hasUse = perms.playerHas(player, Flags.use, true);
 
             if (isButton) {
-                if (perms.playerHas(player, targetFlag, hasUse))
+                if (perms.playerHas(player, Flags.button, hasUse))
                     return;
-
                 event.setCancelled(true);
                 return;
 
             // Easier future addition
             } else if (isPlate) {
-                if (perms.playerHas(player, targetFlag, hasUse))
+                if (perms.playerHas(player, Flags.pressure, hasUse))
                     return;
-
                 event.setCancelled(true);
                 return;
 
@@ -266,21 +254,19 @@ public class ResidenceListener1_13 implements Listener {
             boolean hasUse = perms.has(Flags.use, true);
 
             if (isButton) {
-                if (perms.has(targetFlag, hasUse))
+                if (perms.has(Flags.button, hasUse))
                     return;
-
                 event.setCancelled(true);
                 return;
 
             // Easier future addition
             } else if (isPlate) {
-                if (perms.has(targetFlag, hasUse))
+                if (perms.has(Flags.pressure, hasUse))
                     return;
-
                 event.setCancelled(true);
                 return;
 
-            } 
+            }
         }
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
@@ -27,73 +27,71 @@ public class ResidenceListener1_14 implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler
-    public void onJump(PlayerTakeLecternBookEvent event) {
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onLecternBookTake(PlayerTakeLecternBookEvent event) {
 
         // disabling event on world
         if (plugin.isDisabledWorldListener(event.getLectern().getWorld()))
             return;
-        if (ResAdmin.isResAdmin(event.getPlayer())) {
-            return;
-        }
 
-        if (FlagPermissions.has(event.getLectern().getLocation(), event.getPlayer(), Flags.container, FlagCombo.TrueOrNone))
+        Player player = event.getPlayer();
+
+        if (ResAdmin.isResAdmin(player))
             return;
+
+        FlagPermissions perms = FlagPermissions.getPerms(event.getLectern().getLocation(), player);
+        if (perms.playerHas(player, Flags.container, true))
+            return;
+
+        lm.Flag_Deny.sendMessage(player, Flags.container);
+
         event.setCancelled(true);
-        lm.Flag_Deny.sendMessage(event.getPlayer(), Flags.container);
+
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onRavager(EntityChangeBlockEvent event) {
 
-        // Disabling listener if flag disabled globally
-        if (!Flags.destroy.isGlobalyEnabled())
-            return;
         // disabling event on world
         if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
             return;
-        if (event.isCancelled())
+
+        Entity entity = event.getEntity();
+
+        if (entity.getType() != EntityType.RAVAGER)
             return;
 
-        Entity ent = event.getEntity();
-
-        if (ent.getType() != EntityType.RAVAGER)
-            return;
-
-        if (!FlagPermissions.has(event.getBlock().getLocation(), Flags.destroy, FlagCombo.OnlyFalse))
+        FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation());
+        if (perms.has(Flags.destroy, true))
             return;
 
         event.setCancelled(true);
+
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onVehicleDamage(VehicleDamageEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.vehicledestroy.isGlobalyEnabled())
-            return;
+
         // disabling event on world
         if (plugin.isDisabledWorldListener(event.getVehicle().getWorld()))
             return;
 
-        if (event.isCancelled())
-            return;
-
         Entity attacker = event.getAttacker();
         if (attacker instanceof Player) {
-            if (ResAdmin.isResAdmin((Player) attacker)) {
+
+            Player player = (Player) attacker;
+
+            if (ResAdmin.isResAdmin(player))
                 return;
-            }
-            if (!FlagPermissions.has(event.getVehicle().getLocation(), (Player) attacker, Flags.vehicledestroy, FlagCombo.OnlyFalse))
+
+            FlagPermissions perms = FlagPermissions.getPerms(event.getVehicle().getLocation(), player);
+            if (perms.playerHas(player, Flags.vehicledestroy, true))
                 return;
-        } else {
-            if (!FlagPermissions.has(event.getVehicle().getLocation(), Flags.vehicledestroy, FlagCombo.OnlyFalse))
-                return;
+
+            lm.Flag_Deny.sendMessage(player, Flags.vehicledestroy);
+
+            event.setCancelled(true);
+
         }
-
-        event.setCancelled(true);
-
-        if (attacker instanceof Player)
-            lm.Flag_Deny.sendMessage((Player) attacker, Flags.vehicledestroy);
-
     }
 }


### PR DESCRIPTION
Some minor cleanups to improve readability.

Some large-scale item collection systems rely on Lava and Cacti to destroy Boats and Minecarts, removing the vehicles invincibility state.
Does not affect the previously fixed issue of players knocking back boat.

