### PR TITLE
Add Hook Flag new handling method for 1.21+

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -7,10 +7,12 @@ import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
@@ -146,5 +148,35 @@ public class ResidenceListener1_21 implements Listener {
 
         event.setCancelled(true);
 
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onFishingBobberHit(ProjectileHitEvent event) {
+        // anti NPE
+        Entity HitEntity = event.getHitEntity();
+        if (HitEntity == null)
+            return;
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(HitEntity.getWorld()))
+            return;
+
+        Projectile hook = event.getEntity();
+        // only fishing_bobber
+        if (CMIEntityType.get(hook) != CMIEntityType.FISHING_BOBBER)
+            return;
+        // have player source
+        if (!(hook.getShooter() instanceof Player))
+            return;
+
+        Player player = (Player) hook.getShooter();
+        if (ResAdmin.isResAdmin(player))
+            return;
+
+        FlagPermissions perms = FlagPermissions.getPerms(HitEntity.getLocation(), player);
+        if (perms.playerHas(player, Flags.hook, true))
+            return;
+
+        lm.Flag_Deny.sendMessage(player, Flags.hook);
+        event.setCancelled(true);
     }
 }

--- a/src/main/resources/flags.yml
+++ b/src/main/resources/flags.yml
@@ -200,7 +200,7 @@ Global:
     honeycomb: true
     # Applies to: Both
     # Allows or denys fishing rod hooking entities
-    hook: false
+    hook: true
     # Applies to: Residence
     # Prevent damage from magma blocks
     hotfloor: true
@@ -396,6 +396,7 @@ Global:
     bank: ENDER_CHEST
     beacon: BEACON
     bed: WHITE_BED
+    boarding: ACACIA_BOAT
     brew: BREWING_STAND
     build: BRICKS
     burn: TORCH
@@ -435,6 +436,7 @@ Global:
     fly: ORANGE_CARPET
     friendlyfire: SUNFLOWER
     glow: SEA_LANTERN
+    golemopenchest: COPPER_GOLEM_STATUE
     grow: WHEAT_SEEDS
     healing: POTION
     hidden: GLASS_PANE
@@ -508,90 +510,93 @@ Global:
     harvest: SWEET_BERRIES
     safezone: APPLE
     skulk: SCULK_CATALYST
-    boarding: ACACIA_BOAT
-    golemopenchest: COPPER_GOLEM_STATUE
   # These are default flags applied to all residences from any user group.
   ResidenceDefault:
-    build: false
-    destroy: false
-    use: false
-    container: false
-    pvp: false
-    tnt: false
-    creeper: false
-    ignite: false
-    firespread: false
-    vehicledestroy: false
     animalkilling: false
+    build: false
+    container: false
+    creeper: false
+    destroy: false
+    explode: false
+    firespread: false
+    harvest: false
     hook: false
-    shear: false
+    ignite: false
     leash: false
     pistonprotection: true
-    tp: false
-    explode: false
-    harvest: false
+    pvp: false
+    shear: false
     skulk: false
+    tnt: false
+    tp: false
+    use: false
+    vehicledestroy: false
   # These are default flags applied to the residence creator of any group.
   CreatorDefault:
-    build: true
-    destroy: true
-    move: true
-    use: true
-    ignite: true
-    container: true
     animalkilling: true
-    mobkilling: true
-    vehicledestroy: true
-    trade: true
-    shear: true
-    leash: true
+    build: true
+    container: true
+    destroy: true
     harvest: true
+    hook: true
+    ignite: true
+    leash: true
+    mobkilling: true
+    move: true
+    shear: true
+    trade: true
+    use: true
+    vehicledestroy: true
   # These are default flags applied to the residence renter of any group.
   RentedDefault:
-    container: true
-    ignite: true
-    move: true
-    trade: true
-    mobkilling: true
-    shear: true
-    build: true
-    use: true
-    destroy: true
-    vehicledestroy: true
-    leash: true
-    animalkilling: true
     admin: true
+    animalkilling: true
+    build: true
+    container: true
+    destroy: true
     harvest: true
+    hook: true
+    ignite: true
+    leash: true
+    mobkilling: true
+    move: true
+    shear: true
+    trade: true
+    use: true
+    vehicledestroy: true
   # These are grouped flags, so when using /res pset nickname redstone true, player will get all flags in list, same when setting to false or removing them.
   GroupedFlags:
     redstone:
     - note
-    - pressure
-    - lever
     - button
     - diode
+    - lever
+    - pressure
     craft:
     - brew
-    - table
     - enchant
+    - table
     # This group of flags will be used for padd sub command
     trusted:
-    - use
-    - tp
-    - build
-    - destroy
-    - container
-    - move
-    - leash
     - animalkilling
-    - mobkilling
-    - shear
-    - chat
     - beacon
+    - build
+    - chat
+    - container
+    - destroy
     - harvest
+    - hook
+    - leash
+    - mobkilling
+    - move
+    - shear
+    - trade
+    - tp
+    - use
+    - vehicledestroy
     fire:
-    - ignite
     - firespread
+    - ignite
   # Completely disables defined flag which will no longer be accesable even with resadmin command
   # Can save some of the server processing resources if you don't want to utilize specific checks for specific flags
   TotalFlagDisabling:


### PR DESCRIPTION
The original Hook Flag prevents the hook from being retrieved once it sticks to an entity, causing it to remain attached permanently. Additionally, the hook obstructs the player view.
<img width="854" height="480" alt="2025-10-22_17 45 15" src="https://github.com/user-attachments/assets/c7f48055-33f8-4701-847a-eb77ba558cce" />
<img width="854" height="480" alt="2025-10-22_17 45 29" src="https://github.com/user-attachments/assets/44cccaba-8374-4155-b58a-9f70ea9bb6c9" />


The new method stops the hook from hitting entities, which resolves this issue. It should be able to coexist with the original logic and is only effective for version 1.21+.
<img width="854" height="480" alt="2025-10-22_17 46 35" src="https://github.com/user-attachments/assets/8562b7e7-2f2e-49c1-aa71-7ab2d2fb3f4e" />
