### PR TITLE
Fix hopper stealing from edge Residence container

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.Hopper;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;


### PR DESCRIPTION
When a hopper outside a Residence attempts to take out items from or insert items into a Residence container for interaction, it will be blocked and broken.

As shown in the figure below, the green area is the Residence, and the yellow area is the non-Residence area.
<img width="2560" height="1440" alt="2025-10-23_07 24 22" src="https://github.com/user-attachments/assets/7540bea2-7955-4dd0-b267-4198aba6bb87" />

When both the source and the dest are within Residence areas but not the same one, only the event will be cancelled, and the hopper will not be broken.
This ensures the safety of hoppers at the edges of Residence areas.

can protect all containers at the edge of the Residence from having their items stolen.