### PR TITLE
Fix hopper stealing from edgeResidence container

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
@@ -1,6 +1,5 @@
 package com.bekvon.bukkit.residence.listeners;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -20,6 +19,8 @@ import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
+
+import net.Zrips.CMILib.Version.Schedulers.CMIScheduler;
 
 public class ResidenceListener1_19 implements Listener {
 
@@ -88,11 +89,11 @@ public class ResidenceListener1_19 implements Listener {
     }
 
     private void breakHopper(Inventory hopperInventory) {
+        Location hopperLoc = hopperInventory.getLocation();
+        if (hopperLoc == null)
+            return;
         // delay 1 tick break, ensure after event cancel
-        Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
-            Location hopperLoc = hopperInventory.getLocation();
-            if (hopperLoc == null)
-                return;
+        CMIScheduler.runAtLocationLater(plugin, hopperLoc, () -> {
             Block block = hopperLoc.getBlock();
             // only hopper
             if (block == null || !(block.getType().equals(Material.HOPPER)))


### PR DESCRIPTION
When a hopper outside a Residence attempts to take out items from or insert items into a Residence container for interaction, it will be blocked and broken.

This event is only triggered when there are items that can be moved.
When the container that the hopper is attempting to suck from is empty, this event will not be triggered.

As shown in the figure below, the green area is the Residence, and the yellow area is the non-Residence area.
<img width="2560" height="1440" alt="2025-10-23_07 24 22" src="https://github.com/user-attachments/assets/7540bea2-7955-4dd0-b267-4198aba6bb87" />

When both the source and the dest are within Residence areas but not the same one, only the event will be cancelled, and the hopper will not be broken.
This ensures the safety of hoppers at the edges of Residence areas.

can protect all containers at the edge of the Residence from having their items stolen.