### PR TITLE
small change

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_08.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_08.java
@@ -24,12 +24,20 @@ import com.bekvon.bukkit.residence.utils.Utils;
 public class ResidenceListener1_08 implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerInteractAtArmoStand(PlayerInteractAtEntityEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.container.isGlobalyEnabled())
+            return;
+
         Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player))
+        // disabling event on world
+        if (Residence.getInstance().isDisabledWorldListener(player.getWorld()))
             return;
 
         Entity ent = event.getRightClicked();
         if (!Utils.isArmorStandEntity(ent.getType()))
+            return;
+
+        if (ResAdmin.isResAdmin(player))
             return;
 
         FlagPermissions perms = FlagPermissions.getPerms(ent.getLocation(), player);
@@ -42,12 +50,14 @@ public class ResidenceListener1_08 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void AnimalUnleash(PlayerUnleashEntityEvent event) {
-
-        // disabling event on world
-        if (Residence.getInstance().isDisabledWorldListener(event.getEntity().getWorld()))
+        // Disabling listener if flag disabled globally
+        if (!Flags.leash.isGlobalyEnabled())
             return;
 
         Entity entity = event.getEntity();
+        // disabling event on world
+        if (Residence.getInstance().isDisabledWorldListener(entity.getWorld()))
+            return;
 
         Player player = event.getPlayer();
 
@@ -65,13 +75,15 @@ public class ResidenceListener1_08 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockExplodeEvent(BlockExplodeEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.explode.isGlobalyEnabled())
+            return;
 
         Location loc = event.getBlock().getLocation();
-
+        // disabling event on world
         if (Residence.getInstance().isDisabledWorldListener(loc.getWorld()))
             return;
-        if (event.isCancelled())
-            return;
+
         FlagPermissions world = FlagPermissions.getPerms(loc.getWorld());
         List<Block> preserve = new ArrayList<Block>();
         for (Block block : event.blockList()) {

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_09.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_09.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.ThrownPotion;
+import org.bukkit.entity.Snowman;
 import org.bukkit.event.block.EntityBlockFormEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -44,19 +45,22 @@ public class ResidenceListener1_09 implements Listener {
 
     @EventHandler
     public void EntityToggleGlideEvent(EntityToggleGlideEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.elytra.isGlobalyEnabled())
+            return;
 
+        Entity entity = event.getEntity();
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
+        if (plugin.isDisabledWorldListener(entity.getWorld()))
             return;
 
-        if (!(event.getEntity() instanceof Player))
+        if (!(entity instanceof Player))
             return;
 
-        if (ResAdmin.isResAdmin(event.getEntity())) {
-            return;
-        }
+        Player player = (Player) entity;
 
-        Player player = (Player) event.getEntity();
+        if (ResAdmin.isResAdmin(player))
+            return;
 
         FlagPermissions perms = FlagPermissions.getPerms(player);
 
@@ -75,6 +79,9 @@ public class ResidenceListener1_09 implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onResidenceChange(ResidenceChangedEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.elytra.isGlobalyEnabled())
+            return;
 
         ClaimedResidence newRes = event.getTo();
 
@@ -111,6 +118,10 @@ public class ResidenceListener1_09 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onLingeringSplashPotion(LingeringPotionSplashEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.pvp.isGlobalyEnabled())
+            return;
+
         ProjectileHitEvent ev = event;
         ThrownPotion potion = (ThrownPotion) ev.getEntity();
 
@@ -143,7 +154,9 @@ public class ResidenceListener1_09 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onLingeringEffectApply(AreaEffectCloudApplyEvent event) {
-
+        // Disabling listener if flag disabled globally
+        if (!Flags.pvp.isGlobalyEnabled())
+            return;
         // disabling event on world
         if (Residence.getInstance().isDisabledWorldListener(event.getEntity().getWorld()))
             return;
@@ -205,6 +218,9 @@ public class ResidenceListener1_09 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onFrostWalker(EntityBlockFormEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.build.isGlobalyEnabled())
+            return;
 
         Entity entity = event.getEntity();
         if (entity == null)
@@ -224,6 +240,18 @@ public class ResidenceListener1_09 implements Listener {
 
             FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation(), player);
             if (perms.playerHas(player, Flags.build, true))
+                return;
+
+            event.setCancelled(true);
+            return;
+        }
+
+        // SnowGolem already has SnowTrail Flag
+        // Check all entity trigger FrostWalker
+        // ArmorStand Skeleton Zombies ..
+        if (!(entity instanceof Snowman)) {
+            FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
+            if (perms.has(Flags.build, true))
                 return;
 
             event.setCancelled(true);

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_10.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_10.java
@@ -14,7 +14,10 @@ import com.bekvon.bukkit.residence.protection.FlagPermissions;
 public class ResidenceListener1_10 implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 
-    public void onPlayerFireInteract(EntityDamageEvent event) {
+    public void onEntityHotFloorDamage(EntityDamageEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.hotfloor.isGlobalyEnabled())
+            return;
         // disabling event on world
         if (Residence.getInstance().isDisabledWorldListener(event.getEntity().getWorld()))
             return;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_12.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_12.java
@@ -29,6 +29,7 @@ public class ResidenceListener1_12 implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerPickupItemEvent(EntityPickupItemEvent event) {
+        // Disabling listener if flag disabled globally
         if (!Flags.itempickup.isGlobalyEnabled())
             return;
         ClaimedResidence res = plugin.getResidenceManager().getByLoc(event.getItem().getLocation());
@@ -53,6 +54,9 @@ public class ResidenceListener1_12 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onItemDamage(PlayerItemDamageEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.nodurability.isGlobalyEnabled())
+            return;
         // disabling event on world
         if (Residence.getInstance().isDisabledWorldListener(event.getPlayer().getWorld()))
             return;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
@@ -45,8 +45,6 @@ public class ResidenceListener1_13 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onLandDryFade(BlockFadeEvent event) {
-        if (Version.isCurrentLower(Version.v1_13_R1))
-            return;
         // Disabling listener if flag disabled globally
         if (!Flags.dryup.isGlobalyEnabled())
             return;
@@ -76,8 +74,6 @@ public class ResidenceListener1_13 implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onLandDryPhysics(BlockPhysicsEvent event) {
-        if (Version.isCurrentLower(Version.v1_13_R1))
-            return;
         // Disabling listener if flag disabled globally
         if (!Flags.dryup.isGlobalyEnabled())
             return;
@@ -110,7 +106,10 @@ public class ResidenceListener1_13 implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-    public void onSignInteract(PlayerInteractEvent event) {
+    public void onTrampleTurtleEgg(PlayerInteractEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.destroy.isGlobalyEnabled())
+            return;
         if (!event.getAction().equals(Action.PHYSICAL) || !event.getClickedBlock().getType().equals(Material.TURTLE_EGG))
             return;
         if (!ResidenceBlockListener.canBreakBlock(event.getPlayer(), event.getClickedBlock(), true))
@@ -123,9 +122,9 @@ public class ResidenceListener1_13 implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
-    public void onButtonHitWithProjectile(ProjectileHitEvent event) {
+    public void onProjectileHitButtonPlate(ProjectileHitEvent event) {
         // Disabling listener if flag disabled globally
-        if (!Flags.button.isGlobalyEnabled())
+        if (!Flags.use.isGlobalyEnabled())
             return;
         // Avoid Projectile getWorld NPE
         if (event.getHitBlock() == null)
@@ -206,7 +205,10 @@ public class ResidenceListener1_13 implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onEntityInteractButton(EntityInteractEvent event) {
+    public void onEntityTouchButtonPlate(EntityInteractEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.use.isGlobalyEnabled())
+            return;
 
         Block block = event.getBlock();
         if (block == null)

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
@@ -29,7 +29,9 @@ public class ResidenceListener1_14 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onLecternBookTake(PlayerTakeLecternBookEvent event) {
-
+        // Disabling listener if flag disabled globally
+        if (!Flags.container.isGlobalyEnabled())
+            return;
         // disabling event on world
         if (plugin.isDisabledWorldListener(event.getLectern().getWorld()))
             return;
@@ -51,7 +53,9 @@ public class ResidenceListener1_14 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onRavager(EntityChangeBlockEvent event) {
-
+        // Disabling listener if flag disabled globally
+        if (!Flags.destroy.isGlobalyEnabled())
+            return;
         // disabling event on world
         if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
             return;
@@ -69,7 +73,9 @@ public class ResidenceListener1_14 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onVehicleDamage(VehicleDamageEvent event) {
-
+        // Disabling listener if flag disabled globally
+        if (!Flags.vehicledestroy.isGlobalyEnabled())
+            return;
         // disabling event on world
         if (plugin.isDisabledWorldListener(event.getVehicle().getWorld()))
             return;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16.java
@@ -26,6 +26,9 @@ public class ResidenceListener1_16 implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onLightningStrikeEvent(LightningStrikeEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.animalkilling.isGlobalyEnabled())
+            return;
 
         if (!event.getCause().equals(LightningStrikeEvent.Cause.TRIDENT))
             return;
@@ -42,6 +45,9 @@ public class ResidenceListener1_16 implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPlayerInteractRespawn(PlayerInteractEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.destroy.isGlobalyEnabled())
+            return;
 
         Player player = event.getPlayer();
         if (event.getPlayer() == null)

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_17.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_17.java
@@ -52,6 +52,9 @@ public class ResidenceListener1_17 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockPlace(BlockPlaceEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.place.isGlobalyEnabled())
+            return;
 
         if (ResidenceBlockListener.canPlaceBlock(event.getPlayer(), event.getBlock(), true))
             return;
@@ -74,6 +77,9 @@ public class ResidenceListener1_17 implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPlayerBucketEntityEvent(PlayerBucketEntityEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.animalkilling.isGlobalyEnabled())
+            return;
 
         Player player = event.getPlayer();
         if (ResAdmin.isResAdmin(player))
@@ -98,6 +104,9 @@ public class ResidenceListener1_17 implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerChangeCopper(EntityChangeBlockEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.copper.isGlobalyEnabled())
+            return;
 
         Block block = event.getBlock();
         if (block == null)
@@ -129,7 +138,7 @@ public class ResidenceListener1_17 implements Listener {
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onLandDryPhysics(BlockPhysicsEvent event) {
+    public void onPowderSnowPhysics(BlockPhysicsEvent event) {
 
         // Disabling listener if flag disabled globally
         if (!Flags.place.isGlobalyEnabled())

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_20.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_20.java
@@ -36,6 +36,9 @@ public class ResidenceListener1_20 implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onSignWax(PlayerInteractEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.build.isGlobalyEnabled())
+            return;
 
         Player player = event.getPlayer();
         if (player == null)
@@ -71,6 +74,9 @@ public class ResidenceListener1_20 implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onSignInteract(PlayerSignOpenEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.build.isGlobalyEnabled())
+            return;
 
         Player player = event.getPlayer();
         if (player == null)
@@ -103,6 +109,9 @@ public class ResidenceListener1_20 implements Listener {
     // Sweep SuspiciousBlocks
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onProjectilePlayerChangeBlock(EntityChangeBlockEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.destroy.isGlobalyEnabled())
+            return;
 
         Block block = event.getBlock();
         if (block == null)

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_9_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_9_Paper.java
@@ -23,6 +23,9 @@ public class ResidenceListener1_21_9_Paper implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onCopperGolemInteract(ItemTransportingEntityValidateTargetEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.golemopenchest.isGlobalyEnabled())
+            return;
 
         Entity entity = event.getEntity();
         if (entity == null)


### PR DESCRIPTION
small change:

1. supplement some FlagDisabled

2. Add checks for all entity when they trigger FrostWalker

3. Since the **honey/honeycomb Flag** defaults to "none", block state can be modified, this causes bees to be released from the nest, damage the player, and die as a result. Now, when the **honey/honeycomb Flag** is "none", an additional check on the **destroy Flag** state will be added, while the **honey/honeycomb flag** will still have the highest priority.

 When the **Global honey/honeycomb Flag** or **destroy Flag** is set to **false**, now supports Global to block the collection of honey/honeycomb, and the priority of the **honey/honeycomb Flag** is still higher than that of the **destroy Flag**.

4. Now, when the **Global Boarding Flag** is **false**, it supports globally prohibiting animals from boarding Vehicle, Priority is lower than Residence Flag

5. Now, the **Copper Flag** check for **Copper_Golem** will only be performed when interacting with it while holding HONEYCOMB/AXE, to avoid overriding the **Leash Flag**.
