### PR TITLE
Fix in version 1.20.6  Dispensers cannot dispense Bone_Meal inside Residence

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
@@ -15,7 +15,6 @@ import org.bukkit.inventory.ItemStack;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
@@ -53,9 +52,6 @@ public class ResidenceListener1_19 implements Listener {
             return;
 
         if (!horn.getType().equals(Material.GOAT_HORN))
-            return;
-
-        if (ResAdmin.isResAdmin(player))
             return;
 
         FlagPermissions perms = FlagPermissions.getPerms(player.getLocation(), player);


### PR DESCRIPTION
If Residence Flag_Build: true, external Dispenser will be allowed to place.

If the Dispenser is within a Residence but the target location is not in any Residence, place is allowed.

When the Dispenser is outside a Residence, and either the target location is inside a Residence or the Dispenser and the target location are in different Residences, the build status of the target location will be checked.

It seems that itemType checking is unnecessary. (1.13.2 & 1.20.6)Tests have shown that it does not affect the normal emission of DropItem from the Dispenser, while the placement checks for water, lava, etc. can proceed normally.

fix https://github.com/Zrips/Residence/issues/1356