### PR TITLE
Fix compatibility with 1.16 and lower

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -1407,7 +1407,7 @@ public class ResidencePlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockPlace(BlockPlaceEvent event) {
-        if (!Version.isCurrentEqualOrLower(Version.v1_16_R3) || !Flags.place.isGlobalyEnabled())
+        if (Version.isCurrentEqualOrHigher(Version.v1_17_R1) || !Flags.place.isGlobalyEnabled())
             return;
 
         if (ResidenceBlockListener.canPlaceBlock(event.getPlayer(), event.getBlock(), true))


### PR DESCRIPTION
Residence moved BlockPlaceEvent listener into 1.17+ only listeners in [this commit](https://github.com/Zrips/Residence/commit/55b6c35be87be1a4cf41f4d6059490a9deb4fe5a#diff-f21427fbb35b0ccf49e5ddfc82950cd51a84dab90a550ffa18cb4e7af1336172L687-L708), which breaks compatibility with all versions older than 1.17.