### PR TITLE
Add checks for projectiles hitting the TargetBlock

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/Residence.java
+++ b/src/main/java/com/bekvon/bukkit/residence/Residence.java
@@ -68,6 +68,7 @@ import com.bekvon.bukkit.residence.listeners.ResidenceListener1_13;
 import com.bekvon.bukkit.residence.listeners.ResidenceListener1_14;
 import com.bekvon.bukkit.residence.listeners.ResidenceListener1_15;
 import com.bekvon.bukkit.residence.listeners.ResidenceListener1_16;
+import com.bekvon.bukkit.residence.listeners.ResidenceListener1_16_5_Paper;
 import com.bekvon.bukkit.residence.listeners.ResidenceListener1_17;
 import com.bekvon.bukkit.residence.listeners.ResidenceListener1_19;
 import com.bekvon.bukkit.residence.listeners.ResidenceListener1_20;
@@ -584,6 +585,12 @@ public class Residence extends JavaPlugin {
                     pm.registerEvents(new ResidenceListener1_15(this), this);
                 if (Version.isCurrentEqualOrHigher(Version.v1_16_R1))
                     pm.registerEvents(new ResidenceListener1_16(this), this);
+
+                if (Version.isCurrentEqualOrHigher(Version.v1_16_R3) && Version.isCurrentSubEqualOrHigher(5) || Version.isCurrentEqualOrHigher(Version.v1_17_R1)) {
+                    if (Version.isPaperBranch())
+                        pm.registerEvents(new ResidenceListener1_16_5_Paper(this), this);
+                }
+
                 if (Version.isCurrentEqualOrHigher(Version.v1_17_R1))
                     pm.registerEvents(new ResidenceListener1_17(this), this);
                 if (Version.isCurrentEqualOrHigher(Version.v1_19_R1))

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16_5_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16_5_Paper.java
@@ -1,0 +1,65 @@
+package com.bekvon.bukkit.residence.listeners;
+
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import com.bekvon.bukkit.residence.Residence;
+import com.bekvon.bukkit.residence.containers.Flags;
+import com.bekvon.bukkit.residence.containers.lm;
+import com.bekvon.bukkit.residence.containers.ResAdmin;
+import com.bekvon.bukkit.residence.protection.ClaimedResidence;
+import com.bekvon.bukkit.residence.protection.FlagPermissions;
+import com.bekvon.bukkit.residence.utils.Utils;
+
+import io.papermc.paper.event.block.TargetHitEvent;
+
+public class ResidenceListener1_16_5_Paper implements Listener {
+
+    private Residence plugin;
+
+    public ResidenceListener1_16_5_Paper(Residence plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onHitTargetBlock(TargetHitEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.use.isGlobalyEnabled())
+            return;
+
+        Block block = event.getHitBlock();
+        if (block == null)
+            return;
+
+        if (plugin.isDisabledWorldListener(block.getWorld()))
+            return;
+
+        Player player = Utils.potentialProjectileToPlayer(event.getEntity());
+        if (player != null) {
+
+            if (ResAdmin.isResAdmin(player))
+                return;
+
+            if (FlagPermissions.has(block.getLocation(), player, Flags.use, true))
+                return;
+
+            lm.Flag_Deny.sendMessage(player, Flags.use);
+            event.setCancelled(true);
+
+        } else {
+            // Entity not player source
+            // Check potential block as a shooter which should be allowed if its inside same residence
+            if (Utils.isSourceBlockInsideSameResidence(event.getEntity(), ClaimedResidence.getByLoc(block.getLocation())))
+                return;
+
+            if (FlagPermissions.has(block.getLocation(), Flags.use, true))
+                return;
+
+            event.setCancelled(true);
+
+        }
+    }
+}


### PR DESCRIPTION
Many machines use TargetBlock to control the orientation of Redstone_Wire. When projectiles hit TargetBlock, redstone signals are triggered, and adding this check can prevent projectiles from interfering with the TargetBlock in the machines.
<img width="150" height="150" alt="150px-Target_JE1_BE1" src="https://github.com/user-attachments/assets/480edf7f-5fb4-4d14-9fe4-63f665ddd00f" />
