### PR TITLE
Check for ownership

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/commands/expand.java
+++ b/src/main/java/com/bekvon/bukkit/residence/commands/expand.java
@@ -61,7 +61,12 @@ public class expand implements cmd {
 			return true;
 		}
 
-		if (res.isSubzone() && !resadmin && !ResPerm.command_expand_subzone.hasPermission(player, lm.Subzone_CantExpand))
+        if (!resadmin && !res.isOwner(player)) {
+            lm.Residence_NotOwner.sendMessage(sender);
+            return true;
+        }
+
+        if (res.isSubzone() && !resadmin && !ResPerm.command_expand_subzone.hasPermission(player, lm.Subzone_CantExpand))
 			return true;
 
 		if (!res.isSubzone() && !resadmin && !ResPerm.command_$1.hasPermission(player, lm.Residence_CantExpandResidence, this.getClass().getSimpleName()))


### PR DESCRIPTION
VIP players have the option of having larger residences. However, it is currently possible to circumvent this size limit by having a non-VIP player add a VIP player to their smaller residence, who can then enlarge the residence to VIP size. This allows the limit to be circumvented.

I have fixed this bug, and now only the owner can expand the residence.