### PR TITLE
Add checks when players consume Chorus Fruit

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_09.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_09.java
@@ -18,6 +18,7 @@ import org.bukkit.event.entity.AreaEffectCloudApplyEvent;
 import org.bukkit.event.entity.EntityToggleGlideEvent;
 import org.bukkit.event.entity.LingeringPotionSplashEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.potion.PotionEffect;
 
 import com.bekvon.bukkit.residence.Residence;
@@ -31,6 +32,7 @@ import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 import com.bekvon.bukkit.residence.utils.Teleporting;
 
 import net.Zrips.CMILib.Logs.CMIDebug;
+import net.Zrips.CMILib.Items.CMIMaterial;
 import net.Zrips.CMILib.Version.Version;
 import net.Zrips.CMILib.Version.PaperMethods.PaperLib;
 import net.Zrips.CMILib.Version.Schedulers.CMIScheduler;
@@ -256,6 +258,33 @@ public class ResidenceListener1_09 implements Listener {
                 return;
 
             event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onPlayerEatChorusFruit(PlayerItemConsumeEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.chorustp.isGlobalyEnabled())
+            return;
+
+        Player player = event.getPlayer();
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(player.getWorld()))
+            return;
+
+        CMIMaterial cmat = CMIMaterial.get(event.getItem());
+
+        if (cmat.equals(CMIMaterial.CHORUS_FRUIT)) {
+
+            if (player.hasMetadata("NPC") || ResAdmin.isResAdmin(player))
+                return;
+
+            if (FlagPermissions.has(player.getLocation(), player, Flags.chorustp, true))
+                return;
+
+            lm.Flag_Deny.sendMessage(player, Flags.chorustp);
+            event.setCancelled(true);
+
         }
     }
 }


### PR DESCRIPTION
<img width="2560" height="1440" alt="2025-12-07_04 15 46" src="https://github.com/user-attachments/assets/f18dd543-832f-4036-979f-fb2a7174841f" />

If <Flags.chorustp> is true/none in the yellow area of the diagram, and <Flags.chorustp> is false in the small red area, players in the small red area will be prevented from consuming Chorus Fruit.

Close https://github.com/Zrips/Residence/issues/1305

ps: originally, I also intended to add similar checks for Ender_Pearl usage, but the implementation failed.