### PR TITLE
Do not call vehicleCombust for animals

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
@@ -381,6 +381,9 @@ public class ResidenceEntityListener implements Listener {
         if (!(event.getEntity() instanceof Vehicle))
             return;
 
+        if (Utils.isAnimal(event.getEntity()))
+            return;
+
         Vehicle vehicle = (Vehicle) event.getEntity();
 
         if (!vehicleDamageable(damager, vehicle))


### PR DESCRIPTION
**Bug fix:**
When a player hits an animal with a Fire Aspect sword and the vehicledestroy flag is disabled, the event is canceled and a message about the destroying of the vehicle is sent to the player.