### PR TITLE
Fix potential NPE from mod-added mobs on NeoForge servers, Fix water/lava placement bypass, Flags.iceform no longer overrides Flags.snowtrail

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
@@ -271,17 +271,15 @@ public class ResidenceBlockListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onBlockForm(BlockFormEvent event) {
+    public void onSnowGolemTrailForm(EntityBlockFormEvent event) {
         // Disabling listener if flag disabled globally
         if (!Flags.snowtrail.isGlobalyEnabled())
             return;
         // disabling event on world
         if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
             return;
-        if (!(event instanceof EntityBlockFormEvent))
-            return;
 
-        if (((EntityBlockFormEvent) event).getEntity() instanceof Snowman) {
+        if (event.getEntity() instanceof Snowman) {
             FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
             if (!perms.has(Flags.snowtrail, true)) {
                 event.setCancelled(true);
@@ -297,11 +295,19 @@ public class ResidenceBlockListener implements Listener {
         // disabling event on world
         if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
             return;
-
-        Material ice = Material.getMaterial("FROSTED_ICE");
-
-        if (event.getNewState().getType() != Material.SNOW && event.getNewState().getType() != Material.ICE && ice != null && ice != event.getNewState().getType())
+        // SnowGolem already has SnowTrail Flag
+        if (event instanceof EntityBlockFormEvent
+                && ((EntityBlockFormEvent) event).getEntity() instanceof Snowman) {
             return;
+        }
+
+        CMIMaterial newBlock = CMIMaterial.get(event.getNewState().getType());
+
+        if (newBlock != CMIMaterial.FROSTED_ICE
+                && newBlock != CMIMaterial.ICE
+                && newBlock != CMIMaterial.SNOW) {
+            return;
+        }
 
         FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
         if (!perms.has(Flags.iceform, true)) {

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -239,6 +239,9 @@ public class ResidenceListener1_21 implements Listener {
 
         CMIEntityType type = CMIEntityType.get(entity.getType());
 
+        if (type == null)
+            return;
+
         if (!isFeedingAnimal(type, held))
             return;
 
@@ -255,9 +258,6 @@ public class ResidenceListener1_21 implements Listener {
     }
 
     private boolean isFeedingAnimal(CMIEntityType type, Material held) {
-        if (type == null) {
-            return false;
-        }
         switch (type) {
             case ARMADILLO: return isItemTag(held, "armadillo_food");
             case AXOLOTL: return isItemTag(held, "axolotl_food");

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -255,6 +255,9 @@ public class ResidenceListener1_21 implements Listener {
     }
 
     private boolean isFeedingAnimal(CMIEntityType type, Material held) {
+        if (type == null) {
+            return false;
+        }
         switch (type) {
             case ARMADILLO: return isItemTag(held, "armadillo_food");
             case AXOLOTL: return isItemTag(held, "axolotl_food");
@@ -341,6 +344,9 @@ public class ResidenceListener1_21 implements Listener {
             return false;
 
         CMIEntityType type = CMIEntityType.get(entity);
+        if (type == null)
+            return false;
+
         boolean isBodySlotAir = entInv.getItem(EquipmentSlot.BODY).getType() == Material.AIR;
 
         if (held.containsCriteria(CMIMC.CARPET))

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -1677,20 +1677,18 @@ public class ResidencePlayerListener implements Listener {
         if (ResAdmin.isResAdmin(player))
             return;
 
-        Location loc = event.getBlockClicked().getLocation().clone();
+        Block block = event.getBlockClicked();
 
-        if (Version.isCurrentHigher(Version.v1_12_R1)) {
+        if (CMIMaterial.get(block.getType()) == CMIMaterial.CAULDRON && !player.isSneaking()) {
+            if (FlagPermissions.has(block.getLocation(), player, Flags.build, true))
+                return;
 
-            if (Version.isCurrentHigher(Version.v1_13_R1) && event.getBlockClicked().getBlockData() instanceof org.bukkit.block.data.Waterlogged) {
-                org.bukkit.block.data.Waterlogged waterloggedBlock = (org.bukkit.block.data.Waterlogged) event.getBlockClicked().getBlockData();
-                if (waterloggedBlock.isWaterlogged())
-                    loc.add(event.getBlockFace().getDirection());
-            } else
-                try {
-                    loc.add(event.getBlockFace().getDirection());
-                } catch (Throwable e) {
-                }
+            lm.Flag_Deny.sendMessage(player, Flags.build);
+            event.setCancelled(true);
+            return;
         }
+
+        Location loc = block.getRelative(event.getBlockFace()).getLocation();
 
         CMIMaterial cmat = CMIMaterial.get(event.getBucket());
         ClaimedResidence res = plugin.getResidenceManager().getByLoc(loc);

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -1677,18 +1677,9 @@ public class ResidencePlayerListener implements Listener {
         if (ResAdmin.isResAdmin(player))
             return;
 
-        Block block = event.getBlockClicked();
+        Block clickBlock = event.getBlockClicked();
 
-        if (CMIMaterial.get(block.getType()) == CMIMaterial.CAULDRON && !player.isSneaking()) {
-            if (FlagPermissions.has(block.getLocation(), player, Flags.build, true))
-                return;
-
-            lm.Flag_Deny.sendMessage(player, Flags.build);
-            event.setCancelled(true);
-            return;
-        }
-
-        Location loc = block.getRelative(event.getBlockFace()).getLocation();
+        Location loc = clickBlock.getRelative(event.getBlockFace()).getLocation();
 
         CMIMaterial cmat = CMIMaterial.get(event.getBucket());
         ClaimedResidence res = plugin.getResidenceManager().getByLoc(loc);
@@ -1711,11 +1702,24 @@ public class ResidencePlayerListener implements Listener {
             }
         }
 
-        FlagPermissions perms = FlagPermissions.getPerms(loc, player);
-        if (!perms.playerHas(player, Flags.build, true)) {
-            lm.Flag_Deny.sendMessage(player, Flags.build);
-            event.setCancelled(true);
-            return;
+        // place inside the block
+        if (!player.isSneaking() && ((CMIMaterial.get(clickBlock.getType()) == CMIMaterial.CAULDRON)
+                || (Version.isCurrentEqualOrHigher(Version.v1_13_R1) && clickBlock.getBlockData() instanceof org.bukkit.block.data.Waterlogged))) {
+
+            if (FlagPermissions.has(clickBlock.getLocation(), player, Flags.build, FlagCombo.OnlyFalse)) {
+                lm.Flag_Deny.sendMessage(player, Flags.build);
+                event.setCancelled(true);
+                return;
+            }
+            // place outside the block
+        } else {
+
+            if (FlagPermissions.has(loc ,player, Flags.build, FlagCombo.OnlyFalse)) {
+                lm.Flag_Deny.sendMessage(player, Flags.build);
+                event.setCancelled(true);
+                return;
+            }
+
         }
 
         int level = plugin.getConfigManager().getPlaceLevel();

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -1678,8 +1678,14 @@ public class ResidencePlayerListener implements Listener {
             return;
 
         Block clickBlock = event.getBlockClicked();
-
+        // default place outside the block
         Location loc = clickBlock.getRelative(event.getBlockFace()).getLocation();
+
+        if (!player.isSneaking() && ((CMIMaterial.get(clickBlock.getType()) == CMIMaterial.CAULDRON)
+                || (Version.isCurrentEqualOrHigher(Version.v1_13_R1) && clickBlock.getBlockData() instanceof org.bukkit.block.data.Waterlogged))) {
+            // if place inside the block
+            loc = clickBlock.getLocation();
+        }
 
         CMIMaterial cmat = CMIMaterial.get(event.getBucket());
         ClaimedResidence res = plugin.getResidenceManager().getByLoc(loc);
@@ -1702,24 +1708,10 @@ public class ResidencePlayerListener implements Listener {
             }
         }
 
-        // place inside the block
-        if (!player.isSneaking() && ((CMIMaterial.get(clickBlock.getType()) == CMIMaterial.CAULDRON)
-                || (Version.isCurrentEqualOrHigher(Version.v1_13_R1) && clickBlock.getBlockData() instanceof org.bukkit.block.data.Waterlogged))) {
-
-            if (FlagPermissions.has(clickBlock.getLocation(), player, Flags.build, FlagCombo.OnlyFalse)) {
-                lm.Flag_Deny.sendMessage(player, Flags.build);
-                event.setCancelled(true);
-                return;
-            }
-            // place outside the block
-        } else {
-
-            if (FlagPermissions.has(loc ,player, Flags.build, FlagCombo.OnlyFalse)) {
-                lm.Flag_Deny.sendMessage(player, Flags.build);
-                event.setCancelled(true);
-                return;
-            }
-
+        if (FlagPermissions.has(loc ,player, Flags.build, FlagCombo.OnlyFalse)) {
+            lm.Flag_Deny.sendMessage(player, Flags.build);
+            event.setCancelled(true);
+            return;
         }
 
         int level = plugin.getConfigManager().getPlaceLevel();


### PR DESCRIPTION
Although Residence does not support NeoForge servers, some users may be running hybrid server setups.

Close https://github.com/Zrips/Residence/issues/1401

======

Fixed bypassing water/lava placement at Residence edges by interacting with waterlogged blocks while sneaking

Close https://github.com/Zrips/Residence/issues/1409

Replace https://github.com/Zrips/Residence/pull/1410

(additionally fixed interaction with Cauldron bypass at Residence edges)
<img width="2560" height="1440" alt="2026-02-14_22 41 58" src="https://github.com/user-attachments/assets/d89c2f98-45a2-470d-a4e1-ead45504de51" />

======

Flags.iceform no longer overrides Flags.snowtrail

Close https://github.com/Zrips/Residence/issues/1412