### PR TITLE
Add checks for v26.1 Golden_Dandelion; Add cross region check for Copper_Golem_Statue spawn

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
@@ -301,11 +301,14 @@ public class ResidenceBlockListener implements Listener {
             return;
         }
 
-        CMIMaterial newBlock = CMIMaterial.get(event.getNewState().getType());
+        CMIMaterial mat = CMIMaterial.get(event.getNewState().getType());
 
-        if (newBlock != CMIMaterial.FROSTED_ICE
-                && newBlock != CMIMaterial.ICE
-                && newBlock != CMIMaterial.SNOW) {
+        switch (mat) {
+        case FROSTED_ICE:
+        case ICE:
+        case SNOW:
+            break;
+        default:
             return;
         }
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
@@ -1031,13 +1031,13 @@ public class ResidenceBlockListener implements Listener {
             FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
             if (!perms.has(Flags.firespread, true))
                 event.setCancelled(true);
-        } else if (cause == IgniteCause.FLINT_AND_STEEL) {
+        } else if (event.getPlayer() != null) {
             // Disabling listener if flag disabled globally
             if (!Flags.ignite.isGlobalyEnabled())
                 return;
             Player player = event.getPlayer();
             FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation(), player);
-            if (player != null && !perms.playerHas(player, Flags.ignite, true) && !ResAdmin.isResAdmin(player)) {
+            if (!perms.playerHas(player, Flags.ignite, true) && !ResAdmin.isResAdmin(player)) {
                 event.setCancelled(true);
                 lm.Flag_Deny.sendMessage(player, Flags.ignite);
             }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
@@ -27,6 +27,7 @@ import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.Slime;
+import org.bukkit.entity.Silverfish;
 import org.bukkit.entity.Tameable;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.entity.Vehicle;
@@ -119,7 +120,7 @@ public class ResidenceEntityListener implements Listener {
 
         Entity entity = event.getEntity();
 
-        if (entity instanceof Enderman) {
+        if (entity instanceof Enderman || entity instanceof Silverfish) {
             if (FlagPermissions.has(block.getLocation(), Flags.destroy, FlagCombo.OnlyFalse))
                 event.setCancelled(true);
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
@@ -20,6 +20,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Firework;
 import org.bukkit.entity.Ghast;
 import org.bukkit.entity.Hanging;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Monster;
@@ -183,27 +184,72 @@ public class ResidenceEntityListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
-    public void onEntityInteract(EntityInteractEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.trample.isGlobalyEnabled())
-            return;
-        // disabling event on world
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onEntityInteractEvent(EntityInteractEvent event) {
+
         Block block = event.getBlock();
-        if (block == null)
+        Flags flag = FlagPermissions.checkBlockPhysicalFlag(block);
+        if (flag == null) {
             return;
-        if (plugin.isDisabledWorldListener(block.getWorld()))
+        }
+        Entity entity = event.getEntity();
+        switch (flag) {
+        case destroy:
+            // Turtle Egg: Mob StepOn
+            if (FlagPermissions.has(block.getLocation(), Flags.destroy, true)) {
+                return;
+            }
+            event.setCancelled(true);
             return;
 
-        if (event.getEntity().getType() != EntityType.FALLING_BLOCK)
+        case trample:
+            // Farmland: Mob StepOn
+            FlagPermissions perms = FlagPermissions.getPerms(block.getLocation());
+            if (perms.has(Flags.trample, (perms.has(Flags.build, true)))) {
+                return;
+            }
+            event.setCancelled(true);
             return;
 
-        if (CMIMaterial.get(block.getType()) != CMIMaterial.FARMLAND)
-            return;
+        // Only Button & Pressure_Plate use break(not return) to allow further checks
+        case button:
+            // Button: Projectiles Hit
+            if (!(entity instanceof Projectile)) {
+                return;
+            }
+            break;
 
-        FlagPermissions perms = FlagPermissions.getPerms(block.getLocation());
-        if (perms.has(Flags.trample, perms.has(Flags.build, true)))
+        case pressure:
+            // Pressure Plate: Projectile and Item Touch
+            if (!(entity instanceof Projectile) && !(entity instanceof Item)) {
+                return;
+            }
+            break;
+
+        default:
             return;
+        }
+        Player player = Utils.potentialProjectileToPlayer(entity);
+        if (player != null) {
+
+            if (ResAdmin.isResAdmin(player)) {
+                return;
+            }
+            FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
+            if (perms.playerHas(player, flag, perms.playerHas(player, Flags.use, true))) {
+                return;
+            }
+        } else {
+            // Check potential block as a shooter which should be allowed if its inside same
+            // residence
+            if (Utils.isSourceBlockInsideSameResidence(entity, ClaimedResidence.getByLoc(block.getLocation()))) {
+                return;
+            }
+            FlagPermissions perms = FlagPermissions.getPerms(block.getLocation());
+            if (perms.has(flag, perms.has(Flags.use, true))) {
+                return;
+            }
+        }
 
         event.setCancelled(true);
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_09.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_09.java
@@ -131,8 +131,6 @@ public class ResidenceListener1_09 implements Listener {
         // disabling event on world
         if (Residence.getInstance().isDisabledWorldListener(potion.getWorld()))
             return;
-        if (event.isCancelled())
-            return;
 
         boolean harmfull = false;
         mein: for (PotionEffect one : potion.getEffects()) {
@@ -220,8 +218,9 @@ public class ResidenceListener1_09 implements Listener {
         }
     }
 
+    // FrostWalker form frosted_ice, Wither form wither_rose
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onFrostWalker(EntityBlockFormEvent event) {
+    public void onEntityBlockFormEvent(EntityBlockFormEvent event) {
         // Disabling listener if flag disabled globally
         if (!Flags.build.isGlobalyEnabled())
             return;
@@ -247,18 +246,18 @@ public class ResidenceListener1_09 implements Listener {
                 return;
 
             event.setCancelled(true);
-            return;
-        }
 
-        // SnowGolem already has SnowTrail Flag
-        // Check all entity trigger FrostWalker
-        // ArmorStand Skeleton Zombies ..
-        if (!(entity instanceof Snowman)) {
+            // SnowGolem already has SnowTrail Flag
+            // Check all entity trigger FrostWalker
+            // ArmorStand Skeleton Zombies ...
+        } else if (!(entity instanceof Snowman)) {
+
             FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
             if (perms.has(Flags.build, true))
                 return;
 
             event.setCancelled(true);
+
         }
     }
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
@@ -6,32 +6,24 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.type.Farmland;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Fish;
-import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockFadeEvent;
 import org.bukkit.event.block.BlockPhysicsEvent;
-import org.bukkit.event.entity.EntityInteractEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.containers.lm;
-import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 import com.bekvon.bukkit.residence.utils.Utils;
 
-import net.Zrips.CMILib.Items.CMIMC;
-import net.Zrips.CMILib.Items.CMIMaterial;
 import net.Zrips.CMILib.Version.Version;
 
 public class ResidenceListener1_13 implements Listener {
@@ -86,18 +78,7 @@ public class ResidenceListener1_13 implements Listener {
         return true;
     }
 
-    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-    public void onTrampleTurtleEgg(PlayerInteractEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.destroy.isGlobalyEnabled())
-            return;
-        Block block = event.getClickedBlock();
-        if (block == null || event.getAction() != Action.PHYSICAL || block.getType() != Material.TURTLE_EGG)
-            return;
-        if (!ResidenceBlockListener.canBreakBlock(event.getPlayer(), block.getLocation(), true))
-            event.setCancelled(true);
-    }
-
+    // Send message when player projectile hitting Button/Pressure_Plate is denied
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityInteractDenyMsg(ProjectileHitEvent event) {
 
@@ -107,8 +88,8 @@ public class ResidenceListener1_13 implements Listener {
         }
         Block hitBlockFace = hitBlock.getLocation().clone().add(event.getHitBlockFace().getDirection()).getBlock();
 
-        Flags flag = getBlockFlag(hitBlockFace);
-        if (flag == null) {
+        Flags flag = FlagPermissions.checkBlockPhysicalFlag(hitBlockFace);
+        if (flag != Flags.button && flag != Flags.pressure) {
             return;
         }
 
@@ -124,85 +105,14 @@ public class ResidenceListener1_13 implements Listener {
             return;
 
         // The perfect spot, the earlier check sends exactly one deny msg
-        // for the EntityInteractEvent below to avoid chat spam
+        // avoid chat spam
         lm.Flag_Deny.sendMessage(player, flag);
-
-    }
-
-    private Flags getBlockFlag(Block block) {
-        CMIMaterial mat = CMIMaterial.get(block.getType());
-        Flags flag;
-        if (mat.containsCriteria(CMIMC.BUTTON)) {
-            flag = Flags.button;
-
-        } else if (mat.containsCriteria(CMIMC.PRESSUREPLATE)) {
-            flag = Flags.pressure;
-
-        } else {
-            return null;
-
-        }
-        // Disabling listener if flag disabled globally
-        if (!flag.isGlobalyEnabled()) {
-            return null;
-        }
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld())) {
-            return null;
-        }
-        return flag;
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onEntityInteractEvent(EntityInteractEvent event) {
-
-        Block block = event.getBlock();
-        Flags flag = getBlockFlag(block);
-        if (flag == null) {
-            return;
-        }
-        Entity entity = event.getEntity();
-
-        if (flag == Flags.button) {
-            // Button: Only projectiles
-            if (!(entity instanceof Projectile)) {
-                return;
-            }
-        } else {
-            // Pressure Plate: Projectiles and items
-            if (!(entity instanceof Projectile) && !(entity instanceof Item)) {
-                return;
-            }
-        }
-        Player player = Utils.potentialProjectileToPlayer(entity);
-        if (player != null) {
-
-            if (ResAdmin.isResAdmin(player))
-                return;
-
-            FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
-            if (perms.playerHas(player, flag, perms.playerHas(player, Flags.use, true)))
-                return;
-
-        } else {
-            // Check potential block as a shooter which should be allowed if its inside same
-            // residence
-            if (Utils.isSourceBlockInsideSameResidence(entity, ClaimedResidence.getByLoc(block.getLocation())))
-                return;
-
-            FlagPermissions perms = FlagPermissions.getPerms(block.getLocation());
-            if (perms.has(flag, perms.has(Flags.use, true)))
-                return;
-
-        }
-
-        event.setCancelled(true);
 
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerInteractAtFish(PlayerInteractEntityEvent event) {
-
+        // 1.17+ has PlayerBucketEntityEvent
         if (Version.isCurrentEqualOrHigher(Version.v1_17_R1))
             return;
         // Disabling listener if flag disabled globally

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
@@ -130,25 +130,24 @@ public class ResidenceListener1_13 implements Listener {
     }
 
     private Flags getBlockFlag(Block block) {
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld())) {
-            return null;
-        }
         CMIMaterial mat = CMIMaterial.get(block.getType());
-        CMIMC type;
+        Flags flag;
         if (mat.containsCriteria(CMIMC.BUTTON)) {
-            type = CMIMC.BUTTON;
+            flag = Flags.button;
 
         } else if (mat.containsCriteria(CMIMC.PRESSUREPLATE)) {
-            type = CMIMC.PRESSUREPLATE;
+            flag = Flags.pressure;
 
         } else {
             return null;
 
         }
-        Flags flag = (type == CMIMC.BUTTON) ? Flags.button : Flags.pressure;
         // Disabling listener if flag disabled globally
         if (!flag.isGlobalyEnabled()) {
+            return null;
+        }
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(block.getWorld())) {
             return null;
         }
         return flag;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
@@ -99,35 +99,18 @@ public class ResidenceListener1_13 implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onEntityTouchButtonPlateDenyMsg(ProjectileHitEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.use.isGlobalyEnabled())
-            return;
-        // Avoid Projectile getWorld NPE
+    public void onEntityInteractDenyMsg(ProjectileHitEvent event) {
+
         Block hitBlock = event.getHitBlock();
-        if (hitBlock == null)
+        if (hitBlock == null || event.getHitBlockFace() == null) {
             return;
-
-        if (plugin.isDisabledWorldListener(hitBlock.getWorld()))
-            return;
-
-        if (event.getHitBlockFace() == null)
-            return;
-
-        Block block = hitBlock.getLocation().clone().add(event.getHitBlockFace().getDirection()).getBlock();
-
-        Flags flag = null;
-
-        CMIMaterial cmat = CMIMaterial.get(block.getType());
-
-        if (cmat.containsCriteria(CMIMC.BUTTON)) {
-            flag = Flags.button;
-        } else if (cmat.containsCriteria(CMIMC.PRESSUREPLATE)) {
-            flag = Flags.pressure;
         }
+        Block hitBlockFace = hitBlock.getLocation().clone().add(event.getHitBlockFace().getDirection()).getBlock();
 
-        if (flag == null)
+        Flags flag = getBlockFlag(hitBlockFace);
+        if (flag == null) {
             return;
+        }
 
         Player player = Utils.potentialProjectileToPlayer(event.getEntity());
         if (player == null)
@@ -136,7 +119,7 @@ public class ResidenceListener1_13 implements Listener {
         if (ResAdmin.isResAdmin(player))
             return;
 
-        FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
+        FlagPermissions perms = FlagPermissions.getPerms(hitBlockFace.getLocation(), player);
         if (perms.playerHas(player, flag, perms.playerHas(player, Flags.use, true)))
             return;
 
@@ -146,35 +129,52 @@ public class ResidenceListener1_13 implements Listener {
 
     }
 
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onEntityTouchButtonPlate(EntityInteractEvent event) {
+    private Flags getBlockFlag(Block block) {
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(block.getWorld())) {
+            return null;
+        }
+        CMIMaterial mat = CMIMaterial.get(block.getType());
+        CMIMC type;
+        if (mat.containsCriteria(CMIMC.BUTTON)) {
+            type = CMIMC.BUTTON;
+
+        } else if (mat.containsCriteria(CMIMC.PRESSUREPLATE)) {
+            type = CMIMC.PRESSUREPLATE;
+
+        } else {
+            return null;
+
+        }
+        Flags flag = (type == CMIMC.BUTTON) ? Flags.button : Flags.pressure;
         // Disabling listener if flag disabled globally
-        if (!Flags.use.isGlobalyEnabled())
-            return;
+        if (!flag.isGlobalyEnabled()) {
+            return null;
+        }
+        return flag;
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onEntityInteractEvent(EntityInteractEvent event) {
 
         Block block = event.getBlock();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
+        Flags flag = getBlockFlag(block);
+        if (flag == null) {
             return;
-
-        Entity entity = event.getEntity();
-        // Only check Projectile and DropItem
-        if (!(entity instanceof Projectile) && !(entity instanceof Item))
-            return;
-
-        Flags flag = null;
-
-        CMIMaterial cmat = CMIMaterial.get(block.getType());
-
-        if (cmat.containsCriteria(CMIMC.BUTTON)) {
-            flag = Flags.button;
-        } else if (cmat.containsCriteria(CMIMC.PRESSUREPLATE)) {
-            flag = Flags.pressure;
         }
+        Entity entity = event.getEntity();
 
-        if (flag == null)
-            return;
-
+        if (flag == Flags.button) {
+            // Button: Only projectiles
+            if (!(entity instanceof Projectile)) {
+                return;
+            }
+        } else {
+            // Pressure Plate: Projectiles and items
+            if (!(entity instanceof Projectile) && !(entity instanceof Item)) {
+                return;
+            }
+        }
         Player player = Utils.potentialProjectileToPlayer(entity);
         if (player != null) {
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
@@ -178,7 +178,7 @@ public class ResidenceListener1_14 implements Listener {
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onPlayerharvest(PlayerInteractEvent event) {
+    public void onPlayerInteractHarvest(PlayerInteractEvent event) {
         // Disabling listener if flag disabled globally
         if (!Flags.harvest.isGlobalyEnabled())
             return;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
@@ -11,6 +11,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -136,44 +137,46 @@ public class ResidenceListener1_14 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onProjectileHitBell(ProjectileHitEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.use.isGlobalyEnabled())
-            return;
 
         Block block = event.getHitBlock();
-        if (block == null)
+        if (block == null || block.getType() != Material.BELL) {
             return;
+        }
+        if (shouldBlockProjectileHit(block, event.getEntity(), Flags.use)) {
+            event.setCancelled(true);
+        }
+
+    }
+
+    public static boolean shouldBlockProjectileHit(Block block, Projectile projectile, Flags flag) {
+        // Disabling listener if flag disabled globally
+        if (!flag.isGlobalyEnabled()) {
+            return false;
+        }
         // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
-
-        if (block.getType() != Material.BELL)
-            return;
-
-        Player player = Utils.potentialProjectileToPlayer(event.getEntity());
+        if (Residence.getInstance().isDisabledWorldListener(block.getWorld())) {
+            return false;
+        }
+        Player player = Utils.potentialProjectileToPlayer(projectile);
         if (player != null) {
 
-            if (ResAdmin.isResAdmin(player))
-                return;
-
-            if (FlagPermissions.has(block.getLocation(), player, Flags.use, true))
-                return;
-
-            lm.Flag_Deny.sendMessage(player, Flags.use);
-            event.setCancelled(true);
+            if (ResAdmin.isResAdmin(player)) {
+                return false;
+            }
+            if (FlagPermissions.has(block.getLocation(), player, flag, FlagCombo.OnlyFalse)) {
+                lm.Flag_Deny.sendMessage(player, flag);
+                return true;
+            }
+            return false;
 
         } else {
-            // Entity not player source
+            // projectile not player source
             // Check potential block as a shooter which should be allowed if its inside same
             // residence
-            if (Utils.isSourceBlockInsideSameResidence(event.getEntity(), ClaimedResidence.getByLoc(block.getLocation())))
-                return;
-
-            if (FlagPermissions.has(block.getLocation(), Flags.use, true))
-                return;
-
-            event.setCancelled(true);
-
+            if (Utils.isSourceBlockInsideSameResidence(projectile, ClaimedResidence.getByLoc(block.getLocation()))) {
+                return false;
+            }
+            return FlagPermissions.has(block.getLocation(), flag, FlagCombo.OnlyFalse);
         }
     }
 
@@ -195,7 +198,12 @@ public class ResidenceListener1_14 implements Listener {
 
         CMIMaterial mat = CMIMaterial.get(block.getType());
 
-        if (mat != CMIMaterial.SWEET_BERRY_BUSH && mat != CMIMaterial.CAVE_VINES && mat != CMIMaterial.CAVE_VINES_PLANT) {
+        switch (mat) {
+        case CAVE_VINES:
+        case CAVE_VINES_PLANT:
+        case SWEET_BERRY_BUSH:
+            break;
+        default:
             return;
         }
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
@@ -142,19 +142,16 @@ public class ResidenceListener1_14 implements Listener {
         if (block == null || block.getType() != Material.BELL) {
             return;
         }
-        if (shouldBlockProjectileHit(block, event.getEntity(), Flags.use)) {
+        if (shouldBlockProjectileHit(block, event.getEntity())) {
             event.setCancelled(true);
         }
 
     }
 
-    public static boolean shouldBlockProjectileHit(Block block, Projectile projectile, Flags flag) {
-        // Disabling listener if flag disabled globally
-        if (!flag.isGlobalyEnabled()) {
-            return false;
-        }
-        // disabling event on world
-        if (Residence.getInstance().isDisabledWorldListener(block.getWorld())) {
+    public static boolean shouldBlockProjectileHit(Block block, Projectile projectile) {
+
+        Flags flag = FlagPermissions.checkBlockPhysicalFlag(block);
+        if (flag == null) {
             return false;
         }
         Player player = Utils.potentialProjectileToPlayer(projectile);

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_15.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_15.java
@@ -47,35 +47,33 @@ public class ResidenceListener1_15 implements Listener {
         if (mat != Material.BEE_NEST && mat != Material.BEEHIVE)
             return;
 
-        Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player))
-            return;
+        Flags flag = null;
 
         CMIMaterial heldItem = CMIMaterial.get(event.getItem());
 
         if (heldItem == CMIMaterial.GLASS_BOTTLE) {
-            if (CMILib.getInstance().getReflectionManager().getHoneyLevel(block) < CMILib.getInstance().getReflectionManager().getMaxHoneyLevel(block)) {
-                return;
-            }
-
-            FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
-            if (perms.playerHas(player, Flags.honey, perms.playerHas(player, Flags.build, true)))
-                return;
-
-            lm.Flag_Deny.sendMessage(player, Flags.honey);
-            event.setCancelled(true);
-
+            flag = Flags.honey;
         } else if (heldItem == CMIMaterial.SHEARS) {
-            if (CMILib.getInstance().getReflectionManager().getHoneyLevel(block) < CMILib.getInstance().getReflectionManager().getMaxHoneyLevel(block)) {
-                return;
-            }
-
-            FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
-            if (perms.playerHas(player, Flags.honeycomb, perms.playerHas(player, Flags.build, true)))
-                return;
-
-            lm.Flag_Deny.sendMessage(player, Flags.honeycomb);
-            event.setCancelled(true);
+            flag = Flags.honeycomb;
         }
+
+        if (flag == null)
+            return;
+
+        if (CMILib.getInstance().getReflectionManager().getHoneyLevel(block) < CMILib.getInstance().getReflectionManager().getMaxHoneyLevel(block)) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        if (ResAdmin.isResAdmin(player))
+            return;
+
+        FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
+        if (perms.playerHas(player, flag, perms.playerHas(player, Flags.build, true)))
+            return;
+
+        lm.Flag_Deny.sendMessage(player, flag);
+        event.setCancelled(true);
+
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_15.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_15.java
@@ -17,6 +17,7 @@ import com.bekvon.bukkit.residence.protection.FlagPermissions;
 
 import net.Zrips.CMILib.CMILib;
 import net.Zrips.CMILib.Items.CMIMaterial;
+import net.Zrips.CMILib.Reflections;
 
 public class ResidenceListener1_15 implements Listener {
 
@@ -60,7 +61,9 @@ public class ResidenceListener1_15 implements Listener {
         if (flag == null)
             return;
 
-        if (CMILib.getInstance().getReflectionManager().getHoneyLevel(block) < CMILib.getInstance().getReflectionManager().getMaxHoneyLevel(block)) {
+        Reflections ref = CMILib.getInstance().getReflectionManager();
+
+        if (ref.getHoneyLevel(block) < ref.getMaxHoneyLevel(block)) {
             return;
         }
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16.java
@@ -31,11 +31,11 @@ public class ResidenceListener1_16 implements Listener {
         // Disabling listener if flag disabled globally
         if (!Flags.animalkilling.isGlobalyEnabled())
             return;
-
-        if (!event.getCause().equals(LightningStrikeEvent.Cause.TRIDENT))
-            return;
         // disabling event on world
         if (plugin.isDisabledWorldListener(event.getWorld()))
+            return;
+
+        if (event.getCause() != LightningStrikeEvent.Cause.TRIDENT)
             return;
 
         Player player = Version.isCurrentEqualOrHigher(Version.v1_20_R2)
@@ -59,7 +59,7 @@ public class ResidenceListener1_16 implements Listener {
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPlayerInteractRespawn(PlayerInteractEvent event) {
         // Disabling listener if flag disabled globally
-        if (!Flags.destroy.isGlobalyEnabled())
+        if (!Flags.anchor.isGlobalyEnabled())
             return;
 
         Block block = event.getClickedBlock();
@@ -72,30 +72,19 @@ public class ResidenceListener1_16 implements Listener {
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK)
             return;
 
+        if (block.getType() != Material.RESPAWN_ANCHOR)
+            return;
+
         Player player = event.getPlayer();
         if (ResAdmin.isResAdmin(player))
             return;
 
-        Material mat = block.getType();
+        FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
+        if (perms.playerHas(player, Flags.anchor, perms.playerHas(player, Flags.destroy, true)))
+            return;
 
-        if (mat == Material.RESPAWN_ANCHOR) {
+        lm.Flag_Deny.sendMessage(player, Flags.anchor);
+        event.setCancelled(true);
 
-            FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
-            if (perms.playerHas(player, Flags.anchor, perms.playerHas(player, Flags.destroy, true)))
-                return;
-
-            lm.Flag_Deny.sendMessage(player, Flags.anchor);
-            event.setCancelled(true);
-
-        } else if (mat == Material.REDSTONE_WIRE) {
-
-            FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
-            if (perms.playerHas(player, Flags.build, true))
-                return;
-
-            lm.Flag_Deny.sendMessage(player, Flags.build);
-            event.setCancelled(true);
-
-        }
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16.java
@@ -1,7 +1,9 @@
 package com.bekvon.bukkit.residence.listeners;
 
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.LightningStrike;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -15,6 +17,7 @@ import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
+import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 
 import net.Zrips.CMILib.Version.Version;
 
@@ -28,32 +31,37 @@ public class ResidenceListener1_16 implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onLightningStrikeEvent(LightningStrikeEvent event) {
+
+        if (event.getCause() != LightningStrikeEvent.Cause.TRIDENT) {
+            return;
+        }
+        if (shouldBlockLightning(event.getLightning(), event.getLightning().getLocation())) {
+            event.setCancelled(true);
+        }
+
+    }
+
+    public static boolean shouldBlockLightning(LightningStrike lightning, Location entLoc) {
         // Disabling listener if flag disabled globally
-        if (!Flags.animalkilling.isGlobalyEnabled())
-            return;
+        if (!Flags.animalkilling.isGlobalyEnabled()) {
+            return false;
+        }
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getWorld()))
-            return;
-
-        if (event.getCause() != LightningStrikeEvent.Cause.TRIDENT)
-            return;
-
+        if (Residence.getInstance().isDisabledWorldListener(lightning.getWorld())) {
+            return false;
+        }
         Player player = Version.isCurrentEqualOrHigher(Version.v1_20_R2)
-                ? event.getLightning().getCausingPlayer()
+                ? lightning.getCausingPlayer()
                 : null;
 
         if (player != null) {
-            if (ResAdmin.isResAdmin(player))
-                return;
-            if (FlagPermissions.has(event.getLightning().getLocation(), player, Flags.animalkilling, true))
-                return;
+            if (ResAdmin.isResAdmin(player)) {
+                return false;
+            }
+            return FlagPermissions.has(entLoc, player, Flags.animalkilling, FlagCombo.OnlyFalse);
         } else {
-            if (FlagPermissions.has(event.getLightning().getLocation(), Flags.animalkilling, true))
-                return;
+            return FlagPermissions.has(entLoc, Flags.animalkilling, FlagCombo.OnlyFalse);
         }
-
-        event.setCancelled(true);
-
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16_5_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16_5_Paper.java
@@ -1,6 +1,5 @@
 package com.bekvon.bukkit.residence.listeners;
 
-import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
@@ -8,7 +7,6 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 import com.bekvon.bukkit.residence.Residence;
-import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.utils.Utils;
 import com.destroystokyo.paper.event.entity.EntityZapEvent;
 
@@ -24,12 +22,8 @@ public class ResidenceListener1_16_5_Paper implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onHitTargetBlock(TargetHitEvent event) {
-
-        Block block = event.getHitBlock();
-        if (block == null) {
-            return;
-        }
-        if (ResidenceListener1_14.shouldBlockProjectileHit(block, event.getEntity(), Flags.use)) {
+        // Event only triggered by Projectile hitting TargetBlock
+        if (ResidenceListener1_14.shouldBlockProjectileHit(event.getHitBlock(), event.getEntity())) {
             event.setCancelled(true);
         }
 
@@ -37,7 +31,7 @@ public class ResidenceListener1_16_5_Paper implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityZapEvent(EntityZapEvent event) {
-
+        // Check if animal can be damaged or converted by lightning
         Entity entity = event.getEntity();
         if (!(entity instanceof LivingEntity) || !Utils.isAnimal(entity)) {
             return;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16_5_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16_5_Paper.java
@@ -2,21 +2,15 @@ package com.bekvon.bukkit.residence.listeners;
 
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.containers.lm;
-import com.bekvon.bukkit.residence.containers.ResAdmin;
-import com.bekvon.bukkit.residence.protection.ClaimedResidence;
-import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.utils.Utils;
 import com.destroystokyo.paper.event.entity.EntityZapEvent;
-
-import net.Zrips.CMILib.Version.Version;
 
 import io.papermc.paper.event.block.TargetHitEvent;
 
@@ -30,73 +24,27 @@ public class ResidenceListener1_16_5_Paper implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onHitTargetBlock(TargetHitEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.use.isGlobalyEnabled())
-            return;
 
         Block block = event.getHitBlock();
-        if (block == null)
+        if (block == null) {
             return;
-
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
-
-        Player player = Utils.potentialProjectileToPlayer(event.getEntity());
-        if (player != null) {
-
-            if (ResAdmin.isResAdmin(player))
-                return;
-
-            if (FlagPermissions.has(block.getLocation(), player, Flags.use, true))
-                return;
-
-            lm.Flag_Deny.sendMessage(player, Flags.use);
-            event.setCancelled(true);
-
-        } else {
-            // Entity not player source
-            // Check potential block as a shooter which should be allowed if its inside same
-            // residence
-            if (Utils.isSourceBlockInsideSameResidence(event.getEntity(), ClaimedResidence.getByLoc(block.getLocation())))
-                return;
-
-            if (FlagPermissions.has(block.getLocation(), Flags.use, true))
-                return;
-
-            event.setCancelled(true);
-
         }
+        if (ResidenceListener1_14.shouldBlockProjectileHit(block, event.getEntity(), Flags.use)) {
+            event.setCancelled(true);
+        }
+
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityZapEvent(EntityZapEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.animalkilling.isGlobalyEnabled())
-            return;
 
         Entity entity = event.getEntity();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
+        if (!(entity instanceof LivingEntity) || !Utils.isAnimal(entity)) {
             return;
-
-        if (!Utils.isAnimal(entity))
-            return;
-
-        Player player = Version.isCurrentEqualOrHigher(Version.v1_20_R2)
-                ? event.getBolt().getCausingPlayer()
-                : null;
-
-        if (player != null) {
-            if (ResAdmin.isResAdmin(player))
-                return;
-            if (FlagPermissions.has(entity.getLocation(), player, Flags.animalkilling, true))
-                return;
-        } else {
-            if (FlagPermissions.has(entity.getLocation(), Flags.animalkilling, true))
-                return;
         }
-
-        event.setCancelled(true);
+        if (ResidenceListener1_16.shouldBlockLightning(event.getBolt(), entity.getLocation())) {
+            event.setCancelled(true);
+        }
 
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_17.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_17.java
@@ -19,7 +19,6 @@ import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.player.PlayerBucketEntityEvent;
-import org.bukkit.inventory.ItemStack;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
@@ -84,17 +83,13 @@ public class ResidenceListener1_17 implements Listener {
         if (!Flags.animalkilling.isGlobalyEnabled())
             return;
 
+        Entity ent = event.getEntity();
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(ent.getWorld()))
+            return;
+
         Player player = event.getPlayer();
         if (ResAdmin.isResAdmin(player))
-            return;
-
-        Entity ent = event.getEntity();
-
-        ItemStack iih = event.getOriginalBucket();
-        if (iih == null)
-            return;
-
-        if (!CMIMaterial.get(iih).equals(CMIMaterial.WATER_BUCKET))
             return;
 
         if (FlagPermissions.has(ent.getLocation(), player, Flags.animalkilling, FlagCombo.OnlyFalse)) {
@@ -110,9 +105,6 @@ public class ResidenceListener1_17 implements Listener {
             return;
 
         Block block = event.getBlock();
-        if (block == null)
-            return;
-
         // disabling event on world
         if (plugin.isDisabledWorldListener(block.getWorld()))
             return;
@@ -175,8 +167,6 @@ public class ResidenceListener1_17 implements Listener {
         if (!Flags.build.isGlobalyEnabled())
             return;
         Block block = event.getBlock();
-        if (block == null)
-            return;
         // disabling event on world
         if (plugin.isDisabledWorldListener(block.getWorld()))
             return;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
@@ -8,13 +8,12 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockSpreadEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
@@ -24,6 +23,7 @@ import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 
+import net.Zrips.CMILib.Items.CMIMaterial;
 import net.Zrips.CMILib.Version.Version;
 
 public class ResidenceListener1_19 implements Listener {
@@ -34,31 +34,24 @@ public class ResidenceListener1_19 implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler(priority = EventPriority.NORMAL)
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onUseGoatHorn(PlayerInteractEvent event) {
         // Disabling listener if flag disabled globally
         if (!Flags.goathorn.isGlobalyEnabled())
             return;
 
         Player player = event.getPlayer();
-        if (player == null)
-            return;
         // disabling event on world
         if (plugin.isDisabledWorldListener(player.getWorld()))
             return;
 
-        if (player.hasMetadata("NPC"))
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK)
             return;
 
-        ItemStack horn = event.getItem();
-
-        if (horn == null)
+        if (CMIMaterial.get(event.getItem()) != CMIMaterial.GOAT_HORN)
             return;
 
-        if (!horn.getType().equals(Material.GOAT_HORN))
-            return;
-
-        if (ResAdmin.isResAdmin(player))
+        if (player.hasMetadata("NPC") || ResAdmin.isResAdmin(player))
             return;
 
         FlagPermissions perms = FlagPermissions.getPerms(player.getLocation(), player);
@@ -94,13 +87,8 @@ public class ResidenceListener1_19 implements Listener {
         if (!Flags.container.isGlobalyEnabled())
             return;
 
-        Inventory source = event.getSource();
-        Inventory dest = event.getDestination();
-        if (source == null || dest == null)
-            return;
-
-        ClaimedResidence sourceRes = ClaimedResidence.getByLoc(source.getLocation());
-        ClaimedResidence destRes = ClaimedResidence.getByLoc(dest.getLocation());
+        ClaimedResidence sourceRes = ClaimedResidence.getByLoc(event.getSource().getLocation());
+        ClaimedResidence destRes = ClaimedResidence.getByLoc(event.getDestination().getLocation());
 
         // source & dest not in Res
         if (sourceRes == null && destRes == null)
@@ -171,7 +159,9 @@ public class ResidenceListener1_19 implements Listener {
             return false;
         }
         if(Version.isCurrentEqualOrHigher(Version.v1_21_R7)) {
-            return (entity instanceof AbstractHorse || entity instanceof ChestBoat || entity instanceof org.bukkit.entity.AbstractNautilus);
+            return (entity instanceof AbstractHorse ||
+                    entity instanceof ChestBoat ||
+                    entity instanceof org.bukkit.entity.AbstractNautilus);
         }
         return (entity instanceof AbstractHorse || entity instanceof ChestBoat);
     }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_20.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_20.java
@@ -57,15 +57,17 @@ public class ResidenceListener1_20 implements Listener {
 
     }
 
-    // Projectile hit chorus_flower,decorated_pot,pointed_dripstone
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onProjectileChangeBlock(EntityChangeBlockEvent event) {
-
+        // Only valid for versions 1.20+
         Entity entity = event.getEntity();
         if (!(entity instanceof Projectile)) {
             return;
         }
-        if (ResidenceListener1_14.shouldBlockProjectileHit(event.getBlock(), (Projectile) entity, Flags.destroy)) {
+        // Projectile hit chorus_flower/decorated_pot
+        // Trident hit pointed_dripstone
+        // Flame_Arrow hit tnt
+        if (ResidenceListener1_14.shouldBlockProjectileHit(event.getBlock(), (Projectile) entity)) {
             event.setCancelled(true);
         }
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_20.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_20.java
@@ -15,12 +15,8 @@ import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.containers.lm;
-import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
-import com.bekvon.bukkit.residence.utils.Utils;
-
-import net.Zrips.CMILib.Items.CMIMaterial;
 
 public class ResidenceListener1_20 implements Listener {
 
@@ -64,45 +60,15 @@ public class ResidenceListener1_20 implements Listener {
     // Projectile hit chorus_flower,decorated_pot,pointed_dripstone
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onProjectileChangeBlock(EntityChangeBlockEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.destroy.isGlobalyEnabled())
-            return;
-
-        Block block = event.getBlock();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
 
         Entity entity = event.getEntity();
-
-        if (!(entity instanceof Projectile))
+        if (!(entity instanceof Projectile)) {
             return;
-
-        Player player = Utils.potentialProjectileToPlayer(entity);
-
-        if (player != null) {
-
-            if (ResAdmin.isResAdmin(player))
-                return;
-
-            if (FlagPermissions.has(block.getLocation(), player, Flags.destroy, true))
-                return;
-
-            lm.Flag_Deny.sendMessage(player, Flags.destroy);
-            event.setCancelled(true);
-
-        } else {
-            // Check potential block as a shooter which should be allowed if its inside same
-            // residence
-            if (Utils.isSourceBlockInsideSameResidence(entity, ClaimedResidence.getByLoc(block.getLocation())))
-                return;
-
-            if (FlagPermissions.has(block.getLocation(), Flags.destroy, true))
-                return;
-
-            event.setCancelled(true);
-
         }
+        if (ResidenceListener1_14.shouldBlockProjectileHit(event.getBlock(), (Projectile) entity, Flags.destroy)) {
+            event.setCancelled(true);
+        }
+
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -7,8 +7,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Animals;
+import org.bukkit.entity.Boat;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.Leashable;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Pig;
 import org.bukkit.entity.Player;
@@ -39,6 +39,7 @@ import com.bekvon.bukkit.residence.utils.Utils;
 import net.Zrips.CMILib.Entities.CMIEntityType;
 import net.Zrips.CMILib.Items.CMIMC;
 import net.Zrips.CMILib.Items.CMIMaterial;
+import net.Zrips.CMILib.Version.Version;
 
 public class ResidenceListener1_21 implements Listener {
 
@@ -67,19 +68,28 @@ public class ResidenceListener1_21 implements Listener {
         if (plugin.isDisabledWorldListener(vehicle.getWorld()))
             return;
 
-        if (!(vehicle instanceof Leashable))
-            return;
-        // if vehicle is not leashed, skip check
-        if (!((Leashable) vehicle).isLeashed())
+        if (!(vehicle instanceof Boat))
             return;
 
         Entity entity = event.getEntered();
 
-        if (!(entity instanceof LivingEntity))
+        if (!(entity instanceof LivingEntity) || !Utils.isAnimal(entity))
             return;
 
-        if (!Utils.isAnimal(entity))
-            return;
+        if (Version.isPaperBranch()) {
+            // if vehicle is not leashed, skip check
+            if (!((io.papermc.paper.entity.Leashable) vehicle).isLeashed()) {
+                return;
+            }
+
+        } else if (Version.isCurrentEqualOrHigher(Version.v1_21_R7)) {
+            // spigot
+            if (vehicle instanceof org.bukkit.entity.Leashable
+                    && !((org.bukkit.entity.Leashable) vehicle).isLeashed()) {
+                return;
+            }
+
+        }
 
         ClaimedResidence res = plugin.getResidenceManager().getByLoc(entity.getLocation());
         if (res == null)

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -160,11 +160,19 @@ public class ResidenceListener1_21 implements Listener {
         if (!ent.hasPotionEffect(PotionEffectType.WEAVING))
             return;
 
-        Location loc = ent.getLocation();
-        FlagPermissions perms = FlagPermissions.getPerms(loc);
-        if (perms.has(Flags.build, FlagCombo.TrueOrNone))
-            return;
+        if (ent instanceof Player) {
 
+            Player player = (Player) ent;
+            if (ResAdmin.isResAdmin(player)) {
+                return;
+            }
+            if (FlagPermissions.has(ent.getLocation(), player, Flags.build, true)) {
+                return;
+            }
+
+        } else if (FlagPermissions.has(ent.getLocation(), Flags.build, true)) {
+            return;
+        }
         // Removing weaving effect on death as there is no other way to properly handle
         // this effect inside residence
         ent.removePotionEffect(PotionEffectType.WEAVING);

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -282,12 +282,7 @@ public class ResidenceListener1_21 implements Listener {
                 ? player.getInventory().getItemInOffHand().getType()
                 : player.getInventory().getItemInMainHand().getType();
 
-        CMIEntityType type = CMIEntityType.get(entity.getType());
-
-        if (type == null)
-            return;
-
-        if (!isFeedingAnimal(type, held))
+        if (!isFeedingAnimal((Animals) entity, held))
             return;
 
         if (ResAdmin.isResAdmin(player))
@@ -302,7 +297,14 @@ public class ResidenceListener1_21 implements Listener {
 
     }
 
-    private boolean isFeedingAnimal(CMIEntityType type, Material held) {
+    private boolean isFeedingAnimal(Animals entity, Material held) {
+        if (held.name().equals("GOLDEN_DANDELION")) {
+            return !entity.isAdult();
+        }
+        CMIEntityType type = CMIEntityType.get(entity);
+        if (type == null) {
+            return false;
+        }
         switch (type) {
         case ARMADILLO:
             return isItemTag(held, "armadillo_food");

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -58,7 +58,7 @@ public class ResidenceListener1_21 implements Listener {
 
     // Prevent player from taking away animals in Residence by pulling boat
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onAnimalEntersLeashedStateVehicle(VehicleEnterEvent event) {
+    public void onAnimalEntersLeashedBoat(VehicleEnterEvent event) {
         // Disabling listener if flag disabled globally
         if (!Flags.leash.isGlobalyEnabled())
             return;
@@ -78,7 +78,8 @@ public class ResidenceListener1_21 implements Listener {
 
         if (Version.isPaperBranch()) {
             // if vehicle is not leashed, skip check
-            if (!((io.papermc.paper.entity.Leashable) vehicle).isLeashed()) {
+            if (vehicle instanceof io.papermc.paper.entity.Leashable
+                    && !((io.papermc.paper.entity.Leashable) vehicle).isLeashed()) {
                 return;
             }
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -413,51 +413,30 @@ public class ResidenceListener1_21 implements Listener {
 
     }
 
-    private boolean isBodySlotAir(EntityEquipment entInv) {
-        return entInv.getItem(EquipmentSlot.BODY).getType() == Material.AIR;
-    }
-
     private boolean isEquipFitAnimal(Entity entity, CMIMaterial held) {
-        if (!(entity instanceof LivingEntity))
-            return false;
-
-        EntityEquipment entInv = ((LivingEntity) entity).getEquipment();
-        if (entInv == null)
-            return false;
-
         CMIEntityType type = CMIEntityType.get(entity);
-        if (type == null)
+        if (type == null) {
             return false;
-
-        if (held.containsCriteria(CMIMC.CARPET))
-            return (type == CMIEntityType.LLAMA || type == CMIEntityType.TRADER_LLAMA) && isBodySlotAir(entInv) &&
-                    held != CMIMaterial.MOSS_CARPET && held != CMIMaterial.PALE_MOSS_CARPET;
-
-        if (held.containsCriteria(CMIMC.HARNESS))
-            return type == CMIEntityType.HAPPY_GHAST && isBodySlotAir(entInv);
-
-        if (held.containsCriteria(CMIMC.HORSEARMOR))
-            return (type == CMIEntityType.HORSE || type == CMIEntityType.ZOMBIE_HORSE) && isBodySlotAir(entInv);
-
-        if (held.containsCriteria(CMIMC.NAUTILUSARMOR))
-            return (type == CMIEntityType.NAUTILUS || type == CMIEntityType.ZOMBIE_NAUTILUS) && isBodySlotAir(entInv);
-
+        }
+        EntityEquipment entInv = null;
+        if (entity instanceof LivingEntity) {
+            entInv = ((LivingEntity) entity).getEquipment();
+        }
         if (held == CMIMaterial.SADDLE) {
-
-            if (entity instanceof Pig)
-                return !((Pig) entity).hasSaddle();
-
-            if (entity instanceof Strider)
-                return !((Strider) entity).hasSaddle();
-
             switch (type) {
+            // 1.21.11+ supports EquipmentSlot.SADDLE
+            // Add new Saddle-Equippable entities here in the future
+            case CAMEL_HUSK:
             case NAUTILUS:
             case ZOMBIE_NAUTILUS:
-                // Has Nautilus version, also supports EquipmentSlot.SADDLE
-                return entInv.getItem(EquipmentSlot.SADDLE).getType() == Material.AIR;
-            // Ensure entity is AbstractHorse
+                return entInv != null && entInv.getItem(EquipmentSlot.SADDLE).getType() == Material.AIR;
+
+            // Legacy version compatibility(< 1.21.11)
+            case PIG:
+                return entity instanceof Pig && !((Pig) entity).hasSaddle();
+            case STRIDER:
+                return entity instanceof Strider && !((Strider) entity).hasSaddle();
             case CAMEL:
-            case CAMEL_HUSK:
             case DONKEY:
             case HORSE:
             case MULE:
@@ -474,6 +453,28 @@ public class ResidenceListener1_21 implements Listener {
                 return false;
             }
         }
-        return false;
+        // Non-Saddle Equipment check
+        switch (type) {
+        case LLAMA:
+        case TRADER_LLAMA:
+            if (held.containsCriteria(CMIMC.CARPET) && isBodySlotAir(entInv)) {
+                return held != CMIMaterial.MOSS_CARPET && held != CMIMaterial.PALE_MOSS_CARPET;
+            }
+            return false;
+        case HAPPY_GHAST:
+            return held.containsCriteria(CMIMC.HARNESS) && isBodySlotAir(entInv);
+        case HORSE:
+        case ZOMBIE_HORSE:
+            return held.containsCriteria(CMIMC.HORSEARMOR) && isBodySlotAir(entInv);
+        case NAUTILUS:
+        case ZOMBIE_NAUTILUS:
+            return held.containsCriteria(CMIMC.NAUTILUSARMOR) && isBodySlotAir(entInv);
+        default:
+            return false;
+        }
+    }
+
+    private boolean isBodySlotAir(EntityEquipment entInv) {
+        return entInv != null && entInv.getItem(EquipmentSlot.BODY).getType() == Material.AIR;
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -365,7 +365,7 @@ public class ResidenceListener1_21 implements Listener {
         }
     }
 
-    private static boolean isItemTag(Material item, String tagName) {
+    private boolean isItemTag(Material item, String tagName) {
         return ResidenceListener1_14.isItemTag(item, tagName);
     }
 
@@ -405,7 +405,11 @@ public class ResidenceListener1_21 implements Listener {
 
     }
 
-    private static boolean isEquipFitAnimal(Entity entity, CMIMaterial held) {
+    private boolean isBodySlotAir(EntityEquipment entInv) {
+        return entInv.getItem(EquipmentSlot.BODY).getType() == Material.AIR;
+    }
+
+    private boolean isEquipFitAnimal(Entity entity, CMIMaterial held) {
         if (!(entity instanceof LivingEntity))
             return false;
 
@@ -417,20 +421,18 @@ public class ResidenceListener1_21 implements Listener {
         if (type == null)
             return false;
 
-        boolean isBodySlotAir = entInv.getItem(EquipmentSlot.BODY).getType() == Material.AIR;
-
         if (held.containsCriteria(CMIMC.CARPET))
-            return (type == CMIEntityType.LLAMA || type == CMIEntityType.TRADER_LLAMA) && isBodySlotAir &&
+            return (type == CMIEntityType.LLAMA || type == CMIEntityType.TRADER_LLAMA) && isBodySlotAir(entInv) &&
                     held != CMIMaterial.MOSS_CARPET && held != CMIMaterial.PALE_MOSS_CARPET;
 
         if (held.containsCriteria(CMIMC.HARNESS))
-            return type == CMIEntityType.HAPPY_GHAST && isBodySlotAir;
+            return type == CMIEntityType.HAPPY_GHAST && isBodySlotAir(entInv);
 
         if (held.containsCriteria(CMIMC.HORSEARMOR))
-            return (type == CMIEntityType.HORSE || type == CMIEntityType.ZOMBIE_HORSE) && isBodySlotAir;
+            return (type == CMIEntityType.HORSE || type == CMIEntityType.ZOMBIE_HORSE) && isBodySlotAir(entInv);
 
         if (held.containsCriteria(CMIMC.NAUTILUSARMOR))
-            return (type == CMIEntityType.NAUTILUS || type == CMIEntityType.ZOMBIE_NAUTILUS) && isBodySlotAir;
+            return (type == CMIEntityType.NAUTILUS || type == CMIEntityType.ZOMBIE_NAUTILUS) && isBodySlotAir(entInv);
 
         if (held == CMIMaterial.SADDLE) {
 
@@ -440,12 +442,12 @@ public class ResidenceListener1_21 implements Listener {
             if (entity instanceof Strider)
                 return !((Strider) entity).hasSaddle();
 
-            // Has Nautilus version, also supports EquipmentSlot.SADDLE
-            if (type == CMIEntityType.NAUTILUS || type == CMIEntityType.ZOMBIE_NAUTILUS)
-                return entInv.getItem(EquipmentSlot.SADDLE).getType() == Material.AIR;
-
-            // Ensure entity is AbstractHorse
             switch (type) {
+            case NAUTILUS:
+            case ZOMBIE_NAUTILUS:
+                // Has Nautilus version, also supports EquipmentSlot.SADDLE
+                return entInv.getItem(EquipmentSlot.SADDLE).getType() == Material.AIR;
+            // Ensure entity is AbstractHorse
             case CAMEL:
             case CAMEL_HUSK:
             case DONKEY:

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_9_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_9_Paper.java
@@ -1,15 +1,18 @@
 package com.bekvon.bukkit.residence.listeners;
 
-import org.bukkit.entity.Entity;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
-
-import net.Zrips.CMILib.Entities.CMIEntityType;
+import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 
 import io.papermc.paper.event.entity.ItemTransportingEntityValidateTargetEvent;
 
@@ -23,19 +26,18 @@ public class ResidenceListener1_21_9_Paper implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onCopperGolemInteract(ItemTransportingEntityValidateTargetEvent event) {
+
+        if (!event.isAllowed())
+            return;
         // Disabling listener if flag disabled globally
         if (!Flags.golemopenchest.isGlobalyEnabled())
             return;
 
-        Entity entity = event.getEntity();
-        if (entity == null)
-            return;
-
         // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
+        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
             return;
 
-        if (CMIEntityType.get(entity) != CMIEntityType.COPPER_GOLEM)
+        if (event.getEntityType() != EntityType.COPPER_GOLEM)
             return;
 
         FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
@@ -43,6 +45,45 @@ public class ResidenceListener1_21_9_Paper implements Listener {
             return;
 
         event.setAllowed(false);
+
+    }
+
+    // Prevent external copper golems from forming statues inside Residence
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onCopperGolemStatueForm(EntityChangeBlockEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.build.isGlobalyEnabled())
+            return;
+
+        Block block = event.getBlock();
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(block.getWorld()))
+            return;
+
+        if (event.getEntityType() != EntityType.COPPER_GOLEM)
+            return;
+
+        if (event.getTo() != Material.OXIDIZED_COPPER_GOLEM_STATUE)
+            return;
+
+        ClaimedResidence statueRes = ClaimedResidence.getByLoc(block.getLocation());
+        if (statueRes == null)
+            return;
+
+        Location entSpawnLoc = event.getEntity().getOrigin();
+        if (entSpawnLoc != null) {
+
+            ClaimedResidence entSpawnRes = ClaimedResidence.getByLoc(entSpawnLoc);
+
+            if (entSpawnRes != null && (entSpawnRes == statueRes || entSpawnRes.isOwner(statueRes.getOwner())))
+                return;
+
+        }
+
+        if (statueRes.getPermissions().has(Flags.build, true))
+            return;
+
+        event.setCancelled(true);
 
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -1766,20 +1766,22 @@ public class ResidencePlayerListener implements Listener {
             return;
 
         Block clickBlock = event.getBlockClicked();
-        // default place outside the block
-        Location loc = clickBlock.getRelative(event.getBlockFace()).getLocation();
+        Location loc;
 
         if (!player.isSneaking() && ((CMIMaterial.get(clickBlock.getType()) == CMIMaterial.CAULDRON)
                 || (Version.isCurrentEqualOrHigher(Version.v1_13_R1) && clickBlock.getBlockData() instanceof org.bukkit.block.data.Waterlogged))) {
             // if place inside the block
             loc = clickBlock.getLocation();
+        } else {
+            // place outside the block
+            loc = clickBlock.getRelative(event.getBlockFace()).getLocation();
         }
 
         CMIMaterial cmat = CMIMaterial.get(event.getBucket());
         ClaimedResidence res = plugin.getResidenceManager().getByLoc(loc);
         if (res != null) {
             if (plugin.getConfigManager().preventRentModify() && plugin.getConfigManager().enabledRentSystem()) {
-                if (plugin.getRentManager().isRented(res.getName())) {
+                if (plugin.getRentManager().isRented(res)) {
                     lm.Rent_ModifyDeny.sendMessage(player);
                     event.setCancelled(true);
                     return;
@@ -1833,7 +1835,7 @@ public class ResidencePlayerListener implements Listener {
         Location loc = event.getBlockClicked().getLocation();
 
         ClaimedResidence res = plugin.getResidenceManager().getByLoc(loc);
-        if (res != null && plugin.getConfigManager().preventRentModify() && plugin.getConfigManager().enabledRentSystem() && plugin.getRentManager().isRented(res.getName())) {
+        if (res != null && plugin.getConfigManager().preventRentModify() && plugin.getConfigManager().enabledRentSystem() && plugin.getRentManager().isRented(res)) {
             lm.Rent_ModifyDeny.sendMessage(player);
             event.setCancelled(true);
             return;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -982,47 +982,6 @@ public class ResidencePlayerListener implements Listener {
         return false;
     }
 
-    private boolean isBuildClickBlock(CMIMaterial block, CMIMaterial held) {
-        // Dye or Honeycomb Interact Sign, change Spawner,Pumpkin,Redstone_Wire
-        // check Hoe Interact Rooted_Dirt, Fix upstream dupe
-        // bug(https://github.com/PaperMC/Paper/issues/13536)
-        if (block.containsCriteria(CMIMC.SIGN)) {
-            return held.containsCriteria(CMIMC.DYE) || held == CMIMaterial.HONEYCOMB;
-        }
-        switch (block) {
-        case PUMPKIN:
-            return held == CMIMaterial.SHEARS;
-        case REDSTONE_WIRE:
-            return true;
-        case ROOTED_DIRT:
-            return held.name().contains("_HOE");
-        case SPAWNER:
-        case TRIAL_SPAWNER:
-            return held.containsCriteria(CMIMC.SPAWNEGG);
-        default:
-            break;
-        }
-        return false;
-    }
-
-    private boolean isBuildClickBlockFace(CMIMaterial block, CMIMaterial held) {
-        // place Armor_Stand or End_Crystal
-        // Bone_Meal Interact block, Cocoa_BeansS checks maybe for lower versions
-        switch (held) {
-        case ARMOR_STAND:
-            return true;
-        case BONE_MEAL:
-            return isBlockFertilizable(block);
-        case COCOA_BEANS:
-            return block == CMIMaterial.JUNGLE_LOG || block == CMIMaterial.JUNGLE_WOOD;
-        case END_CRYSTAL:
-            return block == CMIMaterial.BEDROCK || block == CMIMaterial.OBSIDIAN;
-        default:
-            break;
-        }
-        return false;
-    }
-
     private boolean isBlockFertilizable(CMIMaterial block) {
         if (block.containsCriteria(CMIMC.SAPLING)) {
             return true;
@@ -1042,6 +1001,50 @@ public class ResidencePlayerListener implements Listener {
             return true;
         default:
             break;
+        }
+        return false;
+    }
+
+    private boolean isBuildClickBlock(CMIMaterial block, CMIMaterial held) {
+        if(held == CMIMaterial.BONE_MEAL) {
+            return isBlockFertilizable(block);
+        }
+        if (block.containsCriteria(CMIMC.SIGN)) {
+            return held.containsCriteria(CMIMC.DYE) || held == CMIMaterial.HONEYCOMB;
+        }
+        switch (block) {
+        case PUMPKIN:
+            return held == CMIMaterial.SHEARS;
+        case REDSTONE_WIRE:
+            return true;
+        case ROOTED_DIRT:
+            // check Hoe interact Rooted_Dirt, Fix upstream dupe
+            // bug(https://github.com/PaperMC/Paper/issues/13536)
+            return held.name().contains("_HOE");
+        case SPAWNER:
+        case TRIAL_SPAWNER:
+            return held.containsCriteria(CMIMC.SPAWNEGG);
+        default:
+            break;
+        }
+        return false;
+    }
+
+    private boolean isBuildClickBlockFace(CMIMaterial block, CMIMaterial held) {
+        switch (held) {
+        case ARMOR_STAND:
+            return true;
+        case COCOA_BEANS:
+            return block == CMIMaterial.JUNGLE_LOG || block == CMIMaterial.JUNGLE_WOOD;
+        default:
+            break;
+        }
+        return false;
+    }
+
+    private boolean isBuildClickBlockTop(CMIMaterial block, CMIMaterial held) {
+        if (held == CMIMaterial.END_CRYSTAL) {
+            return block == CMIMaterial.BEDROCK || block == CMIMaterial.OBSIDIAN;
         }
         return false;
     }
@@ -1067,12 +1070,16 @@ public class ResidencePlayerListener implements Listener {
             CMIMaterial heldItem = CMIMaterial.get(event.getItem());
             if (isBuildClickBlock(blockType, heldItem)) {
                 loc = block.getLocation();
+
             } else if (isBuildClickBlockFace(blockType, heldItem)) {
                 loc = block.getRelative(event.getBlockFace()).getLocation();
+
+            } else if (isBuildClickBlockTop(blockType, heldItem)) {
+                loc = block.getLocation().clone().add(0, 1, 0);
+
             }
             break;
         case LEFT_CLICK_BLOCK:
-            // Check extinguish Fire by hand, this checks maybe for lower versions
             if (block.getRelative(event.getBlockFace()).getType() == Material.FIRE) {
                 loc = block.getLocation();
             }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -982,6 +982,70 @@ public class ResidencePlayerListener implements Listener {
         return false;
     }
 
+    private boolean isBuildClickBlock(CMIMaterial block, CMIMaterial held) {
+        // Dye or Honeycomb Interact Sign, change Spawner,Pumpkin,Redstone_Wire
+        // check Hoe Interact Rooted_Dirt, Fix upstream dupe
+        // bug(https://github.com/PaperMC/Paper/issues/13536)
+        if (block.containsCriteria(CMIMC.SIGN)) {
+            return held.containsCriteria(CMIMC.DYE) || held == CMIMaterial.HONEYCOMB;
+        }
+        switch (block) {
+        case PUMPKIN:
+            return held == CMIMaterial.SHEARS;
+        case REDSTONE_WIRE:
+            return true;
+        case ROOTED_DIRT:
+            return held.name().contains("_HOE");
+        case SPAWNER:
+        case TRIAL_SPAWNER:
+            return held.containsCriteria(CMIMC.SPAWNEGG);
+        default:
+            break;
+        }
+        return false;
+    }
+
+    private boolean isBuildClickBlockFace(CMIMaterial block, CMIMaterial held) {
+        // place Armor_Stand or End_Crystal
+        // Bone_Meal Interact block, Cocoa_BeansS checks maybe for lower versions
+        switch (held) {
+        case ARMOR_STAND:
+            return true;
+        case BONE_MEAL:
+            return isBlockFertilizable(block);
+        case COCOA_BEANS:
+            return block == CMIMaterial.JUNGLE_LOG || block == CMIMaterial.JUNGLE_WOOD;
+        case END_CRYSTAL:
+            return block == CMIMaterial.BEDROCK || block == CMIMaterial.OBSIDIAN;
+        default:
+            break;
+        }
+        return false;
+    }
+
+    private boolean isBlockFertilizable(CMIMaterial block) {
+        if (block.containsCriteria(CMIMC.SAPLING)) {
+            return true;
+        }
+        // 1.17+ has BlockFertilizeEvent, only need to check the Sapling above
+        if (Version.isCurrentEqualOrHigher(Version.v1_17_R1)) {
+            return false;
+        }
+        switch (block) {
+        case COCOA:
+        case GRASS_BLOCK:
+        case KELP:
+        case KELP_PLANT:
+        case SEAGRASS:
+        case SEA_PICKLE:
+        case SHORT_GRASS:
+            return true;
+        default:
+            break;
+        }
+        return false;
+    }
+
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerBuildWithSpecificItems(PlayerInteractEvent event) {
         // Disabling listener if flag disabled globally
@@ -997,55 +1061,24 @@ public class ResidencePlayerListener implements Listener {
 
         Location loc = null;
 
-        if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-
+        switch (event.getAction()) {
+        case RIGHT_CLICK_BLOCK:
+            CMIMaterial blockType = CMIMaterial.get(block.getType());
             CMIMaterial heldItem = CMIMaterial.get(event.getItem());
-            CMIMaterial bType = CMIMaterial.get(block.getType());
-
-            // Dye or Honeycomb Interact Sign, change Spawner,Pumpkin,Redstone_Wire
-            // check Hoe Interact Rooted_Dirt, Fix upstream dupe
-            // bug(https://github.com/PaperMC/Paper/issues/13536)
-            if ((bType.containsCriteria(CMIMC.SIGN) && (heldItem.containsCriteria(CMIMC.DYE) || heldItem == CMIMaterial.HONEYCOMB))
-                    ||
-                    ((bType == CMIMaterial.SPAWNER || bType == CMIMaterial.TRIAL_SPAWNER) && heldItem.containsCriteria(CMIMC.SPAWNEGG))
-                    ||
-                    (bType == CMIMaterial.PUMPKIN && heldItem == CMIMaterial.SHEARS)
-                    ||
-                    (bType == CMIMaterial.REDSTONE_WIRE)
-                    ||
-                    (bType == CMIMaterial.ROOTED_DIRT && heldItem.name().contains("_HOE"))) {
-
+            if (isBuildClickBlock(blockType, heldItem)) {
                 loc = block.getLocation();
-
-                // place Armor_Stand or End_Crystal
-                // Bone_Meal Interact block, Cocoa_BeansS checks maybe for lower versions
-            } else if (heldItem == CMIMaterial.ARMOR_STAND
-                    ||
-                    (heldItem == CMIMaterial.END_CRYSTAL && (bType == CMIMaterial.BEDROCK || bType == CMIMaterial.OBSIDIAN))
-                    ||
-                    (heldItem == CMIMaterial.COCOA_BEANS && (bType == CMIMaterial.JUNGLE_LOG || bType == CMIMaterial.JUNGLE_WOOD))
-                    ||
-                    (heldItem == CMIMaterial.BONE_MEAL && (bType == CMIMaterial.GRASS_BLOCK ||
-                            bType == CMIMaterial.SHORT_GRASS ||
-                            bType == CMIMaterial.TALL_SEAGRASS ||
-                            bType == CMIMaterial.MOSS_BLOCK ||
-                            bType == CMIMaterial.BIG_DRIPLEAF_STEM ||
-                            bType == CMIMaterial.BIG_DRIPLEAF ||
-                            bType == CMIMaterial.SMALL_DRIPLEAF ||
-                            bType == CMIMaterial.COCOA ||
-                            bType.containsCriteria(CMIMC.SAPLING)))) {
-
+            } else if (isBuildClickBlockFace(blockType, heldItem)) {
                 loc = block.getRelative(event.getBlockFace()).getLocation();
-
             }
-
-        } else if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
+            break;
+        case LEFT_CLICK_BLOCK:
             // Check extinguish Fire by hand, this checks maybe for lower versions
-            if (Material.FIRE != block.getRelative(event.getBlockFace()).getType())
-                return;
-
-            loc = block.getLocation();
-
+            if (block.getRelative(event.getBlockFace()).getType() == Material.FIRE) {
+                loc = block.getLocation();
+            }
+            break;
+        default:
+            return;
         }
 
         if (loc == null)
@@ -1440,12 +1473,29 @@ public class ResidencePlayerListener implements Listener {
         }
     }
 
-    private static boolean canHaveContainer(Entity entity) {
-
-        if (Version.isCurrentEqualOrHigher(Version.v1_19_R1)) {
-            return ResidenceListener1_19.canHaveContainer1_19(entity);
+    private boolean canHaveContainer(Entity entity, Player player) {
+        CMIEntityType type = CMIEntityType.get(entity);
+        if (type != null) {
+            // Click to open container entities
+            switch (type) {
+            case ALLAY:
+            case CHEST_MINECART:
+            case FURNACE_MINECART:
+            case HOPPER_MINECART:
+                return true;
+            default:
+                break;
+            }
         }
-        return entity instanceof AbstractHorse;
+        // Click requires sneaking to open these entity containers
+        // Avoid overriding Flags.riding
+        if (player.isSneaking()) {
+            if (Version.isCurrentEqualOrHigher(Version.v1_19_R1)) {
+                return ResidenceListener1_19.canHaveContainer1_19(entity);
+            }
+            return entity instanceof AbstractHorse;
+        }
+        return false;
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
@@ -1463,14 +1513,8 @@ public class ResidencePlayerListener implements Listener {
             return;
 
         Entity entity = event.getRightClicked();
-        CMIEntityType type = CMIEntityType.get(entity);
 
-        if ((player.isSneaking() && canHaveContainer(entity))
-                ||
-                (type == CMIEntityType.CHEST_MINECART ||
-                        type == CMIEntityType.FURNACE_MINECART ||
-                        type == CMIEntityType.HOPPER_MINECART ||
-                        type == CMIEntityType.ALLAY)) {
+        if (canHaveContainer(entity, player)) {
 
             if (FlagPermissions.has(entity.getLocation(), player, Flags.container, true))
                 return;
@@ -1523,14 +1567,19 @@ public class ResidencePlayerListener implements Listener {
             return;
 
         CMIEntityType type = CMIEntityType.get(entity);
-
-        // Non-rideable Vehicles
-        if (type == CMIEntityType.CHEST_MINECART ||
-                type == CMIEntityType.FURNACE_MINECART ||
-                type == CMIEntityType.HOPPER_MINECART ||
-                type == CMIEntityType.COMMAND_BLOCK_MINECART ||
-                type == CMIEntityType.TNT_MINECART) {
-            return;
+        if (type != null) {
+            // Non-rideable Vehicles
+            switch (type) {
+            case CHEST_MINECART:
+            case COMMAND_BLOCK_MINECART:
+            case FURNACE_MINECART:
+            case HOPPER_MINECART:
+            case SPAWNER_MINECART:
+            case TNT_MINECART:
+                return;
+            default:
+                break;
+            }
         }
 
         Player player = event.getPlayer();

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -1105,62 +1105,44 @@ public class ResidencePlayerListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onPlayerStepOnPressurePlate(PlayerInteractEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.pressure.isGlobalyEnabled())
-            return;
+    public void onPlayerStepOn(PlayerInteractEvent event) {
 
+        if (event.getAction() != Action.PHYSICAL) {
+            return;
+        }
         Block block = event.getClickedBlock();
-        if (block == null)
+        Flags flag = FlagPermissions.checkBlockPhysicalFlag(block);
+        if (flag == null) {
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
-
-        if (event.getAction() != Action.PHYSICAL)
-            return;
-
-        if (!CMIMaterial.get(block.getType()).containsCriteria(CMIMC.PRESSUREPLATE))
-            return;
-
+        }
         Player player = event.getPlayer();
-        if (player.hasMetadata("NPC") || ResAdmin.isResAdmin(player))
+        if (player.hasMetadata("NPC") || (flag != Flags.trample && ResAdmin.isResAdmin(player))) {
             return;
-
+        }
         FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
-        if (perms.playerHas(player, Flags.pressure, (perms.playerHas(player, Flags.use, true))))
-            return;
 
-        event.setCancelled(true);
-    }
-
-    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onPlayerStepOnFarmland(PlayerInteractEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.trample.isGlobalyEnabled())
+        switch (flag) {
+        case destroy:
+            // Turtle Egg
+            if (perms.playerHas(player, Flags.destroy, true)) {
+                return;
+            }
+            break;
+        case pressure:
+            // Pressure Plate
+            if (perms.playerHas(player, Flags.pressure, (perms.playerHas(player, Flags.use, true)))) {
+                return;
+            }
+            break;
+        case trample:
+            // Farmland
+            if (perms.playerHas(player, Flags.trample, (perms.playerHas(player, Flags.build, true)))) {
+                return;
+            }
+            break;
+        default:
             return;
-
-        Block block = event.getClickedBlock();
-        if (block == null)
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
-
-        if (event.getAction() != Action.PHYSICAL)
-            return;
-
-        if (CMIMaterial.get(block.getType()) != CMIMaterial.FARMLAND)
-            return;
-
-        Player player = event.getPlayer();
-        if (player.hasMetadata("NPC"))
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
-        if (perms.playerHas(player, Flags.trample, (perms.playerHas(player, Flags.build, true))))
-            return;
-
+        }
         event.setCancelled(true);
     }
 
@@ -1388,7 +1370,7 @@ public class ResidencePlayerListener implements Listener {
             Flags result = FlagPermissions.getMaterialUseFlagList().get(mat);
             // Residence assigns Flags internally for Material
             if (result != null) {
-                // Start AbstractFlags Check
+                // Start AbstractBlockClickFlag Check
                 main: if (!perms.playerHas(player, result, hasUse)) {
 
                     if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
@@ -1398,16 +1380,16 @@ public class ResidencePlayerListener implements Listener {
                         }
 
                         switch (result) {
+                        case button:
+                            if (ResPerm.bypass_button.hasPermission(player, 10000L))
+                                break main;
+                            break;
                         case container:
                             if (ResPerm.bypass_container.hasPermission(player, 10000L))
                                 break main;
                             break;
                         case door:
                             if (ResPerm.bypass_door.hasPermission(player, 10000L))
-                                break main;
-                            break;
-                        case button:
-                            if (ResPerm.bypass_button.hasPermission(player, 10000L))
                                 break main;
                             break;
                         }
@@ -1426,7 +1408,7 @@ public class ResidencePlayerListener implements Listener {
                     }
                     return;
                 }
-                // End AbstractFlags Check
+                // End AbstractBlockClickFlag Check
             }
         }
         // Restrict custom both-click container use

--- a/src/main/java/com/bekvon/bukkit/residence/protection/FlagPermissions.java
+++ b/src/main/java/com/bekvon/bukkit/residence/protection/FlagPermissions.java
@@ -22,6 +22,7 @@ import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.Nullable;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
@@ -362,6 +363,9 @@ public class FlagPermissions {
 
     }
 
+    // Checks physical interaction flags (trample, projectile hit)
+    // not for right/left-clicking blocks
+    @Nullable
     public static Flags checkBlockPhysicalFlag(Block block) {
         if (block == null) {
             return null;
@@ -369,9 +373,17 @@ public class FlagPermissions {
         CMIMaterial mat = CMIMaterial.get(block.getType());
         Flags flag = null;
         switch (mat) {
+        case BELL:
+        case TARGET:
+            flag = Flags.use;
+            break;
         case FARMLAND:
             flag = Flags.trample;
             break;
+        case CHORUS_FLOWER:
+        case DECORATED_POT:
+        case POINTED_DRIPSTONE:
+        case TNT:
         case TURTLE_EGG:
             flag = Flags.destroy;
             break;

--- a/src/main/java/com/bekvon/bukkit/residence/protection/FlagPermissions.java
+++ b/src/main/java/com/bekvon/bukkit/residence/protection/FlagPermissions.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
@@ -359,6 +360,39 @@ public class FlagPermissions {
             addMaterialToUseFlag(CMIMaterial.CRAFTER.getMaterial(), Flags.table);
         }
 
+    }
+
+    public static Flags checkBlockPhysicalFlag(Block block) {
+        if (block == null) {
+            return null;
+        }
+        CMIMaterial mat = CMIMaterial.get(block.getType());
+        Flags flag = null;
+        switch (mat) {
+        case FARMLAND:
+            flag = Flags.trample;
+            break;
+        case TURTLE_EGG:
+            flag = Flags.destroy;
+            break;
+        default:
+            if (mat.containsCriteria(CMIMC.BUTTON)) {
+                flag = Flags.button;
+            } else if (mat.containsCriteria(CMIMC.PRESSUREPLATE)) {
+                flag = Flags.pressure;
+            }
+            break;
+        }
+        if (flag == null) {
+            return null;
+        }
+        if (!flag.isGlobalyEnabled()) {
+            return null;
+        }
+        if (Residence.getInstance().isDisabledWorldListener(block.getWorld())) {
+            return null;
+        }
+        return flag;
     }
 
     public void parseCommandLimits(ConfigurationSection node) {

--- a/src/main/java/com/bekvon/bukkit/residence/utils/Utils.java
+++ b/src/main/java/com/bekvon/bukkit/residence/utils/Utils.java
@@ -258,13 +258,18 @@ public class Utils {
     }
 
     public static boolean isAnimal(Entity ent) {
+        if (ent == null) {
+            return false;
+        }
+        CMIEntityType type = CMIEntityType.get(ent);
         return (ent instanceof Animals ||
                 ent instanceof WaterMob ||
                 ent instanceof NPC ||
                 ent instanceof Bat ||
                 ent instanceof Snowman ||
                 ent instanceof IronGolem ||
-                (ent != null && (CMIEntityType.get(ent) == CMIEntityType.ALLAY || CMIEntityType.get(ent) == CMIEntityType.COPPER_GOLEM)));
+                type == CMIEntityType.ALLAY ||
+                type == CMIEntityType.COPPER_GOLEM);
     }
 
     public static boolean isArmorStandEntity(EntityType ent) {


### PR DESCRIPTION
This PR mainly focuses on streamlining and reducing redundancy, with several minor improvements.

Small Change:

1. [Golden_Dandelion](https://minecraft.wiki/w/Golden_Dandelion), added in version 26.1, can lock or unlock the growth state of baby animals when fed. This PR also adds protection checks for this feature.

2. Add check for [Silverfish](https://minecraft.wiki/w/Silverfish#Behavior) Infested Block(Silverfish replace many blocks; when damaged, they break those blocks to summon allies).

3. now support globally setting Flags.itempickup & Flags.vehicledestroy.

4. fixed Flags.nodurability not working for offhand tools.

5. when Flags.brush is set to none, it now checks Flags.build instead of Flags.destroy.

6. fixed issue where left-clicking with GOAT_HORN could not break blocks when Flags.goathorn was false.

7. if a boat is not leashed when an animal enters it, nearby players' Flags.leash permission is no longer checked(Paper1.21+ or Spigot1.21.11+).

8. Prevent external copper golems from forming statues inside Residence(Paper1.21.9+).

9. Added protection against Mob trampling on farmland and turtle eggs.

10. Allow trigger if the player can build and has the WEAVING effect.

~~removed some redundant isCancelled() checks.~~
~~added support for globally disabled flags for certain checks.~~