### PR TITLE
feat: Add protection for v26.2 SulfurCube, Add Flags.copperoxidation and Flags.raid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,13 @@
         <dependency>
 			<groupId>io.papermc.paper</groupId>
 			<artifactId>paper-api</artifactId>
-			<version>1.21.11-R0.1-SNAPSHOT</version>
+			<version>26.1.2.build.69-stable</version>
 			<scope>provided</scope>
 		</dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.21.11-R0.1-SNAPSHOT</version>
+            <version>26.1.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -66,14 +66,14 @@
 		<dependency>
 			<groupId>com.github.Zrips</groupId>
 			<artifactId>CMILib</artifactId>
-			<version>1.5.8.1</version>
+			<version>1.5.9.6</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- CMI -->
 		<dependency>
 			<groupId>com.github.Zrips</groupId>
 			<artifactId>CMI-API</artifactId>
-			<version>9.7.14.3</version>
+			<version>9.8.6.4</version>
 			<scope>provided</scope> 
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,13 +22,13 @@
         <dependency>
 			<groupId>io.papermc.paper</groupId>
 			<artifactId>paper-api</artifactId>
-			<version>26.1.2.build.69-stable</version>
+			<version>26.2.build.34-alpha</version>
 			<scope>provided</scope>
 		</dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>26.1.2-R0.1-SNAPSHOT</version>
+            <version>26.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -79,7 +79,7 @@
 		<dependency>
 		    <groupId>com.github.Slimefun</groupId>
 		    <artifactId>Slimefun4</artifactId>
-		    <version>5374034</version>
+		    <version>RC-37</version>
 		    <scope>provided</scope>
 		</dependency>		
 		<!-- Pl3xMap -->

--- a/src/main/java/com/bekvon/bukkit/residence/containers/Flags.java
+++ b/src/main/java/com/bekvon/bukkit/residence/containers/Flags.java
@@ -36,6 +36,7 @@ public enum Flags {
     container(CMIMaterial.CHEST_MINECART, FlagMode.Both, "Allows or denys use of furnaces, chests, dispensers, etc...", true),
     coords(CMIMaterial.COMPASS, FlagMode.Residence, "Hides residence coordinates", true),
     copper(CMIMaterial.COPPER_BLOCK, FlagMode.Both, "Allows to modify copper blocks", true),
+	copperoxidation(CMIMaterial.OXIDIZED_COPPER, FlagMode.Residence, "Allow or deny all copper blocks oxidation", true),
     coraldryup(CMIMaterial.FIRE_CORAL, FlagMode.Residence, "Allow or deny all corals from drying up", true),
     craft(CMIMaterial.STONE, FlagMode.Residence, "Gives table, enchant, brew flags", true),
     creeper(CMIMaterial.CREEPER_SPAWN_EGG, FlagMode.Residence, "Allow or deny creeper explosions", true),

--- a/src/main/java/com/bekvon/bukkit/residence/containers/Flags.java
+++ b/src/main/java/com/bekvon/bukkit/residence/containers/Flags.java
@@ -104,6 +104,7 @@ public enum Flags {
     pistonprotection(CMIMaterial.STICKY_PISTON, FlagMode.Residence, "Enables or disabled piston block move in or out of residence", true),
     place(CMIMaterial.SEA_LANTERN, FlagMode.Both, "Allows or denys only placement of blocks, overrides the build flag", true),
     pvp(CMIMaterial.WOODEN_SWORD, FlagMode.Residence, "Allow or deny pvp in the residence", false),
+	raid(CMIMaterial.CROSSBOW, FlagMode.Residence, "Allow or deny vanilla raid trigger in the residence", true),
     rain(CMIMaterial.BLUE_ORCHID, FlagMode.Residence, "Sets weather to rainny in residence", true),
     respawn(CMIMaterial.SUNFLOWER, FlagMode.Residence, "Automaticaly respawns player", false),
     riding(CMIMaterial.SADDLE, FlagMode.Both, "Prevent riding a horse", true),

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
@@ -290,12 +290,12 @@ public class ResidenceBlockListener implements Listener {
     private boolean isIceOrSnow(Material material) {
         CMIMaterial mat = CMIMaterial.get(material);
         switch (mat) {
-            case FROSTED_ICE:
-            case ICE:
-            case SNOW:
-                return true;
-            default:
-                return false;
+        case FROSTED_ICE:
+        case ICE:
+        case SNOW:
+            return true;
+        default:
+            return false;
         }
     }
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
@@ -287,6 +287,18 @@ public class ResidenceBlockListener implements Listener {
         }
     }
 
+    private boolean isIceOrSnow(Material material) {
+        CMIMaterial mat = CMIMaterial.get(material);
+        switch (mat) {
+            case FROSTED_ICE:
+            case ICE:
+            case SNOW:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onIceForm(BlockFormEvent event) {
         // Disabling listener if flag disabled globally
@@ -300,18 +312,9 @@ public class ResidenceBlockListener implements Listener {
                 && ((EntityBlockFormEvent) event).getEntity() instanceof Snowman) {
             return;
         }
-
-        CMIMaterial mat = CMIMaterial.get(event.getNewState().getType());
-
-        switch (mat) {
-        case FROSTED_ICE:
-        case ICE:
-        case SNOW:
-            break;
-        default:
+        if (!isIceOrSnow(event.getNewState().getType())) {
             return;
         }
-
         FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
         if (!perms.has(Flags.iceform, true)) {
             event.setCancelled(true);
@@ -327,10 +330,9 @@ public class ResidenceBlockListener implements Listener {
         if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
             return;
 
-        if (!CMIMaterial.get(event.getNewState().getType()).equals(CMIMaterial.WATER) && event.getBlock().getState().getType() != Material.SNOW && event.getBlock().getState()
-                .getType() != Material.SNOW_BLOCK)
+        if (!isIceOrSnow(event.getBlock().getType())) {
             return;
-
+        }
         FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
         if (!perms.has(Flags.icemelt, true)) {
             event.setCancelled(true);

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_09.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_09.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.ThrownPotion;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.CauldronLevelChangeEvent;
 import org.bukkit.event.block.EntityBlockFormEvent;
 import org.bukkit.event.entity.AreaEffectCloudApplyEvent;
 import org.bukkit.event.entity.EntityToggleGlideEvent;
@@ -286,5 +287,34 @@ public class ResidenceListener1_09 implements Listener {
             event.setCancelled(true);
 
         }
+    }
+
+    // Bucket, glass_bottle, potion, pattern banners & dyed shulker_boxes change cauldron level
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onCauldronLevelChange(CauldronLevelChangeEvent event) {
+        // Disabling listener if flag disabled globally
+        if (!Flags.build.isGlobalyEnabled()) {
+            return;
+        }
+        Entity entity = event.getEntity();
+        if (entity == null) {
+            return;
+        }
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(entity.getWorld())) {
+            return;
+        }
+        if (!(entity instanceof Player)) {
+            return;
+        }
+        Player player = (Player) entity;
+        if (ResAdmin.isResAdmin(player)) {
+            return;
+        }
+        if (FlagPermissions.has(event.getBlock().getLocation(), player, Flags.build, true)) {
+            return;
+        }
+        lm.Flag_Deny.sendMessage(player, Flags.build);
+        event.setCancelled(true);
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
@@ -21,6 +22,7 @@ import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerTakeLecternBookEvent;
+import org.bukkit.event.raid.RaidTriggerEvent;
 import org.bukkit.event.vehicle.VehicleDamageEvent;
 
 import com.bekvon.bukkit.residence.Residence;
@@ -236,4 +238,20 @@ public class ResidenceListener1_14 implements Listener {
             event.setCancelled(true);
 
     }
+
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	public void onVanillaRaidTrigger(RaidTriggerEvent event) {
+		// Disabling listener if flag disabled globally
+		if (!Flags.raid.isGlobalyEnabled()) {
+			return;
+		}
+		Location raidLoc = event.getRaid().getLocation();
+		// disabling event on world
+		if (plugin.isDisabledWorldListener(raidLoc.getWorld())) {
+			return;
+		}
+		if (FlagPermissions.has(raidLoc, Flags.raid, FlagCombo.OnlyFalse)) {
+			event.setCancelled(true);
+		}
+	}
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_17.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_17.java
@@ -15,6 +15,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockFertilizeEvent;
+import org.bukkit.event.block.BlockFormEvent;
 import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
@@ -29,6 +30,7 @@ import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 
+import net.Zrips.CMILib.Items.CMIMC;
 import net.Zrips.CMILib.Items.CMIMaterial;
 import net.Zrips.CMILib.Version.Version;
 
@@ -129,6 +131,33 @@ public class ResidenceListener1_17 implements Listener {
         event.setCancelled(true);
 
     }
+
+	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+	public void onCopperOxidation(BlockFormEvent event) {
+		// Disabling listener if flag disabled globally
+		if (!Flags.copperoxidation.isGlobalyEnabled()) {
+			return;
+		}
+		Block block = event.getBlock();
+		// disabling event on world
+		if (plugin.isDisabledWorldListener(block.getWorld())) {
+			return;
+		}
+		if (!isUnwaxedCopper(block)) {
+			return;
+		}
+		if (FlagPermissions.has(block.getLocation(), Flags.copperoxidation, FlagCombo.OnlyFalse)) {
+			event.setCancelled(true);
+		}
+	}
+
+	private boolean isUnwaxedCopper(Block block) {
+		CMIMaterial mat = CMIMaterial.get(block.getType());
+		if (mat.containsCriteria(CMIMC.COPPER)) {
+			return !mat.name().startsWith("WAXED_");
+		}
+		return false;
+	}
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPowderSnowPhysics(BlockPhysicsEvent event) {

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
@@ -107,7 +107,7 @@ public class ResidenceListener1_19 implements Listener {
                     destRes.getPermissions().has(Flags.container, true))
                 return;
 
-            // source in Res, destRes definitely not in Res
+            // source in Res, dest definitely not in Res
         } else if (sourceRes != null) {
 
             if (sourceRes.getPermissions().has(Flags.container, true))
@@ -158,11 +158,8 @@ public class ResidenceListener1_19 implements Listener {
         if (entity == null) {
             return false;
         }
-        if(Version.isCurrentEqualOrHigher(Version.v1_21_R7)) {
-            return (entity instanceof AbstractHorse ||
-                    entity instanceof ChestBoat ||
-                    entity instanceof org.bukkit.entity.AbstractNautilus);
-        }
-        return (entity instanceof AbstractHorse || entity instanceof ChestBoat);
+        return entity instanceof AbstractHorse
+                || entity instanceof ChestBoat
+                || (Version.isCurrentEqualOrHigher(Version.v1_21_11) && entity instanceof org.bukkit.entity.AbstractNautilus);
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -3,13 +3,14 @@ package com.bekvon.bukkit.residence.listeners;
 import java.util.HashMap;
 import java.util.UUID;
 
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.Ageable;
 import org.bukkit.entity.Animals;
 import org.bukkit.entity.Boat;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
 import org.bukkit.entity.Pig;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -273,7 +274,7 @@ public class ResidenceListener1_21 implements Listener {
         if (plugin.isDisabledWorldListener(entity.getWorld()))
             return;
 
-        if (!(entity instanceof Animals))
+        if (!(entity instanceof Mob))
             return;
 
         Player player = event.getPlayer();
@@ -282,7 +283,7 @@ public class ResidenceListener1_21 implements Listener {
                 ? player.getInventory().getItemInOffHand().getType()
                 : player.getInventory().getItemInMainHand().getType();
 
-        if (!isFeedingAnimal((Animals) entity, held))
+        if (!isFeedingAnimal((Mob) entity, held))
             return;
 
         if (ResAdmin.isResAdmin(player))
@@ -297,9 +298,13 @@ public class ResidenceListener1_21 implements Listener {
 
     }
 
-    private boolean isFeedingAnimal(Animals entity, Material held) {
+    private boolean isFeedingAnimal(Mob entity, Material held) {
         if (CMIMaterial.get(held) == CMIMaterial.GOLDEN_DANDELION) {
-            return !entity.isAdult();
+            return entity instanceof Ageable && !((Ageable)entity).isAdult();
+        }
+        // Temporary code, replace with enum after CMILib new GitHub Releases release
+        if (Version.isCurrentEqualOrHigher(Version.v26_2_0) && entity instanceof org.bukkit.entity.SulfurCube) {
+            return isItemTag(held, "sulfur_cube_food") || isItemTag(held, "sulfur_cube_swallowable");
         }
         CMIEntityType type = CMIEntityType.get(entity);
         if (type == null) {
@@ -396,7 +401,7 @@ public class ResidenceListener1_21 implements Listener {
 
         // check if held item and interacted entity match
         // if conditions match, also check if the target entity slot is Air
-        if (!isEquipFitAnimal(entity, CMIMaterial.get(held)))
+        if (!isEquipFitAnimal((Animals) entity, CMIMaterial.get(held)))
             return;
 
         if (ResAdmin.isResAdmin(player))
@@ -410,14 +415,10 @@ public class ResidenceListener1_21 implements Listener {
 
     }
 
-    private boolean isEquipFitAnimal(Entity entity, CMIMaterial held) {
+    private boolean isEquipFitAnimal(Animals entity, CMIMaterial held) {
         CMIEntityType type = CMIEntityType.get(entity);
         if (type == null) {
             return false;
-        }
-        EntityEquipment entInv = null;
-        if (entity instanceof LivingEntity) {
-            entInv = ((LivingEntity) entity).getEquipment();
         }
         if (held == CMIMaterial.SADDLE) {
             switch (type) {
@@ -426,7 +427,7 @@ public class ResidenceListener1_21 implements Listener {
             case CAMEL_HUSK:
             case NAUTILUS:
             case ZOMBIE_NAUTILUS:
-                return entInv != null && entInv.getItem(EquipmentSlot.SADDLE).getType() == Material.AIR;
+                return isSlotAir(entity, EquipmentSlot.SADDLE);
 
             // Legacy version compatibility(< 1.21.11)
             case PIG:
@@ -439,13 +440,13 @@ public class ResidenceListener1_21 implements Listener {
             case MULE:
             case SKELETON_HORSE:
             case ZOMBIE_HORSE:
-                if (!(entity instanceof AbstractHorse)) {
-                    return false;
+                if (entity instanceof AbstractHorse) {
+                    ItemStack horseSaddle = ((AbstractHorse) entity).getInventory().getSaddle();
+                    // Do not use horseSaddle != null
+                    // Saddle slot Air, getSaddle() returns null, result always false
+                    return horseSaddle == null || horseSaddle.getType() == Material.AIR;
                 }
-                ItemStack horseSaddle = ((AbstractHorse) entity).getInventory().getSaddle();
-                // Do not use horseSaddle != null
-                // Saddle slot Air, getSaddle() returns null, result always false
-                return horseSaddle == null || horseSaddle.getType() == Material.AIR;
+                return false;
             default:
                 return false;
             }
@@ -454,24 +455,25 @@ public class ResidenceListener1_21 implements Listener {
         switch (type) {
         case LLAMA:
         case TRADER_LLAMA:
-            if (held.containsCriteria(CMIMC.CARPET) && isBodySlotAir(entInv)) {
+            if (held.containsCriteria(CMIMC.CARPET) && isSlotAir(entity, EquipmentSlot.BODY)) {
                 return held != CMIMaterial.MOSS_CARPET && held != CMIMaterial.PALE_MOSS_CARPET;
             }
             return false;
         case HAPPY_GHAST:
-            return held.containsCriteria(CMIMC.HARNESS) && isBodySlotAir(entInv);
+            return held.containsCriteria(CMIMC.HARNESS) && isSlotAir(entity, EquipmentSlot.BODY);
         case HORSE:
         case ZOMBIE_HORSE:
-            return held.containsCriteria(CMIMC.HORSEARMOR) && isBodySlotAir(entInv);
+            return held.containsCriteria(CMIMC.HORSEARMOR) && isSlotAir(entity, EquipmentSlot.BODY);
         case NAUTILUS:
         case ZOMBIE_NAUTILUS:
-            return held.containsCriteria(CMIMC.NAUTILUSARMOR) && isBodySlotAir(entInv);
+            return held.containsCriteria(CMIMC.NAUTILUSARMOR) && isSlotAir(entity, EquipmentSlot.BODY);
         default:
             return false;
         }
     }
 
-    private boolean isBodySlotAir(EntityEquipment entInv) {
-        return entInv != null && entInv.getItem(EquipmentSlot.BODY).getType() == Material.AIR;
+    private boolean isSlotAir(Animals entity, EquipmentSlot slot) {
+        EntityEquipment equipment = entity.getEquipment();
+        return equipment != null && equipment.getItem(slot).getType() == Material.AIR;
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -298,7 +298,7 @@ public class ResidenceListener1_21 implements Listener {
     }
 
     private boolean isFeedingAnimal(Animals entity, Material held) {
-        if (held.name().equals("GOLDEN_DANDELION")) {
+        if (CMIMaterial.get(held) == CMIMaterial.GOLDEN_DANDELION) {
             return !entity.isAdult();
         }
         CMIEntityType type = CMIEntityType.get(entity);
@@ -321,8 +321,11 @@ public class ResidenceListener1_21 implements Listener {
         case CHICKEN:
             return isItemTag(held, "chicken_food");
         case COW:
+        case MOOSHROOM:
             return isItemTag(held, "cow_food");
         case DONKEY:
+        case HORSE:
+        case MULE:
             return isItemTag(held, "horse_food");
         case FOX:
             return isItemTag(held, "fox_food");
@@ -334,15 +337,11 @@ public class ResidenceListener1_21 implements Listener {
             return isItemTag(held, "happy_ghast_food");
         case HOGLIN:
             return isItemTag(held, "hoglin_food");
-        case HORSE:
-            return isItemTag(held, "horse_food");
         case LLAMA:
+        case TRADER_LLAMA:
             return isItemTag(held, "llama_food");
-        case MOOSHROOM:
-            return isItemTag(held, "cow_food");
-        case MULE:
-            return isItemTag(held, "horse_food");
         case NAUTILUS:
+        case ZOMBIE_NAUTILUS:
             return isItemTag(held, "nautilus_food");
         case OCELOT:
             return isItemTag(held, "ocelot_food");
@@ -360,16 +359,12 @@ public class ResidenceListener1_21 implements Listener {
             return isItemTag(held, "sniffer_food");
         case STRIDER:
             return isItemTag(held, "strider_food");
-        case TRADER_LLAMA:
-            return isItemTag(held, "llama_food");
         case TURTLE:
             return isItemTag(held, "turtle_food");
         case WOLF:
             return isItemTag(held, "wolf_food") || held == Material.BONE;
         case ZOMBIE_HORSE:
             return held == Material.RED_MUSHROOM;
-        case ZOMBIE_NAUTILUS:
-            return isItemTag(held, "nautilus_food");
         default:
             return false;
         }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -1013,6 +1013,9 @@ public class ResidencePlayerListener implements Listener {
             return held.containsCriteria(CMIMC.DYE) || held == CMIMaterial.HONEYCOMB;
         }
         switch (block) {
+        case CAULDRON:
+            // Cauldron uses CauldronLevelChangeEvent for checks on 1.9+
+            return Version.isCurrentLower(Version.v1_9_0) && (held == CMIMaterial.GLASS_BOTTLE || held == CMIMaterial.POTION);
         case PUMPKIN:
             return held == CMIMaterial.SHEARS;
         case REDSTONE_WIRE:
@@ -1766,10 +1769,14 @@ public class ResidencePlayerListener implements Listener {
             return;
 
         Block clickBlock = event.getBlockClicked();
+        boolean isCauldron = CMIMaterial.get(clickBlock.getType()) == CMIMaterial.CAULDRON;
+        // Cauldron uses CauldronLevelChangeEvent for checks on 1.9+
+        if (isCauldron && Version.isCurrentEqualOrHigher(Version.v1_9_0)) {
+            return;
+        }
         Location loc;
 
-        if (!player.isSneaking() && ((CMIMaterial.get(clickBlock.getType()) == CMIMaterial.CAULDRON)
-                || (Version.isCurrentEqualOrHigher(Version.v1_13_R1) && clickBlock.getBlockData() instanceof org.bukkit.block.data.Waterlogged))) {
+        if (!player.isSneaking() && (isCauldron || (Version.isCurrentEqualOrHigher(Version.v1_13_0) && clickBlock.getBlockData() instanceof org.bukkit.block.data.Waterlogged))) {
             // if place inside the block
             loc = clickBlock.getLocation();
         } else {
@@ -1831,7 +1838,10 @@ public class ResidencePlayerListener implements Listener {
         Player player = event.getPlayer();
         if (ResAdmin.isResAdmin(player))
             return;
-
+        // Cauldron uses CauldronLevelChangeEvent for checks on 1.9+
+        if (Version.isCurrentEqualOrHigher(Version.v1_9_0) && CMIMaterial.get(event.getBlockClicked().getType()) == CMIMaterial.WATER_CAULDRON) {
+            return;
+        }
         Location loc = event.getBlockClicked().getLocation();
 
         ClaimedResidence res = plugin.getResidenceManager().getByLoc(loc);

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -1758,6 +1758,22 @@ public class ResidencePlayerListener implements Listener {
         event.setCancelled(true);
     }
 
+    private boolean isCauldron(Block block) {
+        if (block == null) {
+            return false;
+        }
+        CMIMaterial mat = CMIMaterial.get(block.getType());
+        switch (mat) {
+        case CAULDRON:
+        case LAVA_CAULDRON:
+        case POWDER_SNOW_CAULDRON:
+        case WATER_CAULDRON:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerBucketEmpty(PlayerBucketEmptyEvent event) {
         // disabling event on world
@@ -1769,7 +1785,7 @@ public class ResidencePlayerListener implements Listener {
             return;
 
         Block clickBlock = event.getBlockClicked();
-        boolean isCauldron = CMIMaterial.get(clickBlock.getType()) == CMIMaterial.CAULDRON;
+        boolean isCauldron = isCauldron(clickBlock);
         // Cauldron uses CauldronLevelChangeEvent for checks on 1.9+
         if (isCauldron && Version.isCurrentEqualOrHigher(Version.v1_9_0)) {
             return;
@@ -1839,7 +1855,7 @@ public class ResidencePlayerListener implements Listener {
         if (ResAdmin.isResAdmin(player))
             return;
         // Cauldron uses CauldronLevelChangeEvent for checks on 1.9+
-        if (Version.isCurrentEqualOrHigher(Version.v1_9_0) && CMIMaterial.get(event.getBlockClicked().getType()) == CMIMaterial.WATER_CAULDRON) {
+        if (Version.isCurrentEqualOrHigher(Version.v1_9_0) && isCauldron(event.getBlockClicked())) {
             return;
         }
         Location loc = event.getBlockClicked().getLocation();

--- a/src/main/java/com/bekvon/bukkit/residence/utils/Utils.java
+++ b/src/main/java/com/bekvon/bukkit/residence/utils/Utils.java
@@ -261,15 +261,27 @@ public class Utils {
         if (ent == null) {
             return false;
         }
+        if (ent instanceof Animals
+                || ent instanceof WaterMob
+                || ent instanceof NPC
+                || ent instanceof Bat
+                || ent instanceof Snowman
+                || ent instanceof IronGolem
+                // Temporary code, replace with enum after CMILib new GitHub Releases release
+                || (Version.isCurrentEqualOrHigher(Version.v26_2_0) && ent instanceof org.bukkit.entity.SulfurCube)) {
+            return true;
+        }
         CMIEntityType type = CMIEntityType.get(ent);
-        return (ent instanceof Animals ||
-                ent instanceof WaterMob ||
-                ent instanceof NPC ||
-                ent instanceof Bat ||
-                ent instanceof Snowman ||
-                ent instanceof IronGolem ||
-                type == CMIEntityType.ALLAY ||
-                type == CMIEntityType.COPPER_GOLEM);
+        if (type != null) {
+            switch (type) {
+            case ALLAY:
+            case COPPER_GOLEM:
+                return true;
+            default:
+                return false;
+            }
+        }
+        return false;
     }
 
     public static boolean isArmorStandEntity(EntityType ent) {

--- a/src/main/resources/flags.yml
+++ b/src/main/resources/flags.yml
@@ -97,6 +97,9 @@ Global:
     # Allows to modify copper blocks
     copper: true
     # Applies to: Residence
+    # Allow or deny all copper blocks oxidation
+    copperoxidation: true
+    # Applies to: Residence
     # Allow or deny all corals from drying up
     coraldryup: true
     # Applies to: Residence
@@ -425,6 +428,7 @@ Global:
     container: CHEST_MINECART
     coords: COMPASS
     copper: COPPER_BLOCK
+    copperoxidation: OXIDIZED_COPPER
     coraldryup: FIRE_CORAL
     craft: STONE
     creeper: CREEPER_SPAWN_EGG

--- a/src/main/resources/flags.yml
+++ b/src/main/resources/flags.yml
@@ -307,6 +307,9 @@ Global:
     # Allow or deny pvp in the residence
     pvp: false
     # Applies to: Residence
+    # Allow or deny vanilla raid trigger in the residence
+    raid: true
+    # Applies to: Residence
     # Sets weather to rainny in residence
     rain: true
     # Applies to: Residence
@@ -499,6 +502,7 @@ Global:
     place: SEA_LANTERN
     pressure: LIGHT_WEIGHTED_PRESSURE_PLATE
     pvp: WOODEN_SWORD
+    raid: CROSSBOW
     rain: BLUE_ORCHID
     respawn: SUNFLOWER
     riding: SADDLE


### PR DESCRIPTION
1. Add protection for v26.2 SulfurCube
(SulfurCube is a friendly mob, so it is included in animal protection rules. A feeding verification check has also been implemented for this entity~~SulfurCube’s diet is incredibly varied—this mob will eat almost anything!)
<img width="300" height="334" alt="300px-Sulfur_Cube_JE2" src="https://github.com/user-attachments/assets/2ab0a4e1-1bc7-460f-b4b1-a4527ea0901e" />

2. Add Flags.CopperOxidation: Controls whether copper blocks can oxidize.
<img width="600" height="338" alt="600px-All_Oxidizing_Blocks" src="https://github.com/user-attachments/assets/441e3f91-3132-41b3-b072-8b5a8f5c973d" />

3. Add Flags.Raid: Control whether vanilla raid can be triggered
(Raid spawns boss bar, sound effects and raider mobs. Villagers are commonly kept inside residences and players reported outsiders deliberately triggering nearby raids to harass them, which can be annoying. The raid will now be cancelled if the Flags.raid flag at the raid’s spawn center is set to false.)
<img width="550" height="291" alt="550px-Raid" src="https://github.com/user-attachments/assets/5dc19481-2098-4dab-afd6-f1f917e9d093" />

4. Fix Flags.icemelt: false fails to prevent ice melting in the Nether.
(Packed ice melting in the Nether does not return WATER via getNewState)
<img width="2560" height="1441" alt="2026-06-25_01 19 27" src="https://github.com/user-attachments/assets/69f8db7e-a8f9-4fb6-bf64-97b589a1eb18" />

5. Fix Cauldron protection bypass.
(Cauldron has 4 block type IDs with rich interaction logic, Using CauldronLevelChangeEvent provides more comprehensive overwrite protection)
<img width="2560" height="1441" alt="2026-06-25_01 21 23" src="https://github.com/user-attachments/assets/612c5432-442c-443c-8f61-dea0914d1245" />
