### PR TITLE
Fix GUI attribute visibility on 1.20.5+ servers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 		<dependency>
 		    <groupId>com.github.Slimefun</groupId>
 		    <artifactId>Slimefun4</artifactId>
-		    <version>5374034</version>
+		    <version>RC-37</version>
 		    <scope>provided</scope>
 		</dependency>		
 		<!-- Pl3xMap -->

--- a/src/main/java/com/bekvon/bukkit/residence/gui/setFlagInfo.java
+++ b/src/main/java/com/bekvon/bukkit/residence/gui/setFlagInfo.java
@@ -15,6 +15,11 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
+import com.google.common.collect.HashMultimap;
+
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.containers.lm;
@@ -28,6 +33,7 @@ import net.Zrips.CMILib.Container.CMIText;
 import net.Zrips.CMILib.Enchants.CMIEnchantEnum;
 import net.Zrips.CMILib.GUI.CMIGuiButton;
 import net.Zrips.CMILib.GUI.GUIManager.GUIClickType;
+import net.Zrips.CMILib.Version.Version;
 
 public class setFlagInfo {
 
@@ -361,6 +367,8 @@ public class setFlagInfo {
             lore.addAll(description.get(flag));
         lore.addAll(lm.Gui_Actions.getMessageList());
         MiscInfoMeta.setLore(lore);
+        if (Version.isCurrentEqualOrHigher(Version.v1_20_R4))
+            MiscInfoMeta.setAttributeModifiers(HashMultimap.<Attribute, AttributeModifier>create());
         miscInfo.setItemMeta(MiscInfoMeta);
 
         return miscInfo;


### PR DESCRIPTION
On 1.20.5+ (v1_20_R4), the old HIDE_ATTRIBUTES ItemFlag no longer hides
item attributes in inventory GUIs. Set an empty AttributeModifiers map on
the ItemMeta instead to properly suppress attribute display.

Fixes #1440