### PR TITLE
Apply wspeed flags immediately on player login inside residence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 		<dependency>
 		    <groupId>com.github.Slimefun</groupId>
 		    <artifactId>Slimefun4</artifactId>
-		    <version>5374034</version>
+		    <version>RC-37</version>
 		    <scope>provided</scope>
 		</dependency>		
 		<!-- Pl3xMap -->

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -912,6 +912,13 @@ public class ResidencePlayerListener implements Listener {
 
         CMIScheduler.runAtEntityLater(plugin, player, () -> {
             handleNewLocation(player, player.getLocation(), true);
+            ClaimedResidence res = plugin.getResidenceManager().getByLoc(player.getLocation());
+            if (res != null) {
+                if (Flags.wspeed1.isGlobalyEnabled() && res.getPermissions().has(Flags.wspeed1, FlagCombo.OnlyTrue))
+                    player.setWalkSpeed(plugin.getConfigManager().getWalkSpeed1().floatValue());
+                else if (Flags.wspeed2.isGlobalyEnabled() && res.getPermissions().has(Flags.wspeed2, FlagCombo.OnlyTrue))
+                    player.setWalkSpeed(plugin.getConfigManager().getWalkSpeed2().floatValue());
+            }
         }, 1L);
 
         plugin.getPlayerManager().playerJoin(player);


### PR DESCRIPTION
wspeed1/wspeed2 flags were not applied when a player logged in while
already inside a flagged residence. The async ResidenceChangedEvent chain
(callAsync -> runAtLocation) races with Minecraft's login ability packet,
causing the speed to be overridden. Fix by directly setting walk speed in
the synchronous delayed task after handleNewLocation.

Fixes #1444