### PR TITLE
Fix: setall and setallfor permission bypass

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/commands/setall.java
+++ b/src/main/java/com/bekvon/bukkit/residence/commands/setall.java
@@ -49,7 +49,7 @@ public class setall implements cmd {
         for (World oneW : Bukkit.getWorlds()) {
             for (ClaimedResidence one : plugin.getResidenceManager().getFromAllResidences(true, false, oneW)) {
                 count2++;
-                if (one.getPermissions().setFlag(sender, flag, state, true, false))
+                if (one.getPermissions().setFlag(sender, flag, state, resadmin, false))
                     count++;
             }
         }

--- a/src/main/java/com/bekvon/bukkit/residence/commands/setall.java
+++ b/src/main/java/com/bekvon/bukkit/residence/commands/setall.java
@@ -5,12 +5,14 @@ import java.util.Arrays;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 import net.Zrips.CMILib.FileHandler.ConfigReader;
 import com.bekvon.bukkit.residence.LocaleManager;
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.CommandAnnotation;
 import com.bekvon.bukkit.residence.containers.Flags;
+import com.bekvon.bukkit.residence.containers.ResidencePlayer;
 import com.bekvon.bukkit.residence.containers.cmd;
 import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
@@ -46,13 +48,26 @@ public class setall implements cmd {
 
         int count = 0;
         int count2 = 0;
-        for (World oneW : Bukkit.getWorlds()) {
-            for (ClaimedResidence one : plugin.getResidenceManager().getFromAllResidences(true, false, oneW)) {
+
+        if (resadmin) {
+            for (World oneW : Bukkit.getWorlds()) {
+                for (ClaimedResidence one : plugin.getResidenceManager().getFromAllResidences(true, false, oneW)) {
+                    count2++;
+                    if (one.getPermissions().setFlag(sender, flag, state, resadmin, false))
+                        count++;
+                }
+            }
+        } else {
+            if (!(sender instanceof Player))
+                return false;
+            ResidencePlayer resPlayer = plugin.getPlayerManager().getResidencePlayer((Player) sender);
+            for (ClaimedResidence one : resPlayer.getResList()) {
                 count2++;
                 if (one.getPermissions().setFlag(sender, flag, state, resadmin, false))
                     count++;
             }
         }
+
         lm.Flag_ChangedFor.sendMessage(sender, count, count2);
 
         return true;

--- a/src/main/java/com/bekvon/bukkit/residence/commands/setallfor.java
+++ b/src/main/java/com/bekvon/bukkit/residence/commands/setallfor.java
@@ -51,7 +51,7 @@ public class setallfor implements cmd {
         int count = 0;
 
         for (ClaimedResidence one : resPlayer.getResList()) {
-            if (one.getPermissions().setFlag(sender, flag, state, true, false))
+            if (one.getPermissions().setFlag(sender, flag, state, resadmin, false))
                 count++;
         }
 


### PR DESCRIPTION
### Problem
#1466 

`/res setall` and `/res setallfor` hardcode `resadmin=true` when calling `setFlag()`, which causes `ResidencePermissions.checkCanSetFlag()` to skip all permission verification. Any player with `residence.command.*` can modify flags on every residence server-wide without being an admin or owner.

### Fix

**`setallfor.java`** — Changed hardcoded `resadmin=true` to pass the actual `resadmin` parameter:
```java
// Before
setFlag(sender, flag, state, true, false)
// After
setFlag(sender, flag, state, resadmin, false)
```
Non-admin players can no longer modify other players' residences via `setallfor`.

**setall.java** — Same `resadmin` fix, plus added scope restriction for non-admin users:
- **Admin**: operates on all residences across all worlds (unchanged behavior)
- **Non-admin**: only operates on their own residences

```java
if (resadmin) {
    // All worlds, all residences
} else {
    // Only the sender's own residences
}
```
