### PR TITLE
Fix SulfurCubeBucket and TNT bypassing protection, along with some other changes

### DIFF
--- a/src/main/java/com/bekvon/bukkit/residence/ConfigManager.java
+++ b/src/main/java/com/bekvon/bukkit/residence/ConfigManager.java
@@ -33,6 +33,7 @@ import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.containers.GenMessageType;
 import com.bekvon.bukkit.residence.containers.RandomTeleport;
 import com.bekvon.bukkit.residence.containers.lm;
+import com.bekvon.bukkit.residence.listenersCache.DenyMessageCache;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagState;
 import com.bekvon.bukkit.residence.selection.VisualizerConfig;
@@ -151,6 +152,7 @@ public class ConfigManager {
     private boolean chatListening;
     private GenMessageType GeneralMessageType;
     protected List<String> MessageType;
+    protected int FlagDenyMessageCooldown;
 
     protected boolean ActionBarOnSelection;
     protected boolean visualizer;
@@ -1181,6 +1183,14 @@ public class ConfigManager {
         c.addComment("Global.Messages.MessageType", "Classified under Language MessageType of GeneralMessages");
         MessageType = new ArrayList<>(c.get("Global.Messages.MessageType", Arrays.asList("Flag_Deny", "Residence_FlagDeny", "General_NoPVPZone")));
 
+        c.addComment("Global.Messages.FlagDenyMessageCooldown", "Cooldown for sending duplicate Flag deny messages, in seconds(default: 1)",
+                "Only effective for 1.16+ versions; suppresses spam from repeated Flag deny messages");
+        FlagDenyMessageCooldown = (c.get("Global.Messages.FlagDenyMessageCooldown", 1));
+
+        if (Version.isCurrentEqualOrHigher(Version.v1_16_0) && FlagDenyMessageCooldown > 0) {
+            DenyMessageCache.reloadDenyMessageCache(FlagDenyMessageCooldown);
+        }
+
         ActionBarOnSelection = c.get("Global.ActionBar.ShowOnSelection", true);
 
         c.addComment("Global.ResidenceChatEnable", "Enable or disable residence chat channels.");
@@ -2073,6 +2083,10 @@ public class ConfigManager {
 
     public List<String> getMessageType() {
         return MessageType;
+    }
+
+    public int getFlagDenyMessageCooldown() {
+        return FlagDenyMessageCooldown;
     }
 
     @Deprecated

--- a/src/main/java/com/bekvon/bukkit/residence/ConfigManager.java
+++ b/src/main/java/com/bekvon/bukkit/residence/ConfigManager.java
@@ -197,6 +197,7 @@ public class ConfigManager {
     private int SelectionNetherHeight = 128;
     protected boolean NoCostForYBlocks = false;
     protected boolean WorldEditIntegration = false;
+    protected boolean DisabledWorld;
     protected boolean DisableListeners;
     protected boolean DisableCommands;
     private boolean DisableResidenceCreation;
@@ -652,6 +653,15 @@ public class ConfigManager {
         DisableCommands = c.get("Global.Optimizations.DisabledWorlds.DisableCommands", true);
         c.addComment("Global.Optimizations.DisabledWorlds.DisableResidenceCreation", "Disables residence creation in included worlds");
         DisableResidenceCreation = c.get("Global.Optimizations.DisabledWorlds.DisableResidenceCreation", true);
+
+        if (DisabledWorldsList.isEmpty() && EnabledWorldsList.isEmpty()) {
+            DisabledWorld = false;
+            DisableListeners = false;
+            DisableCommands = false;
+            DisableResidenceCreation = false;
+        } else {
+            DisabledWorld = true;
+        }
 
         c.addComment("Global.Optimizations.ItemPickUpDelay", "Delay in seconds between item pickups after residence flag prevents it", "Keep it at arround 10 sec to lower unesecery checks");
         ItemPickUpDelay = c.get("Global.Optimizations.ItemPickUpDelay", 10);

--- a/src/main/java/com/bekvon/bukkit/residence/ConfigManager.java
+++ b/src/main/java/com/bekvon/bukkit/residence/ConfigManager.java
@@ -201,6 +201,7 @@ public class ConfigManager {
     protected boolean DisableListeners;
     protected boolean DisableCommands;
     private boolean DisableResidenceCreation;
+    private boolean HopperCrossResidenceCheck;
 
     // Town
 //    private boolean TownEnabled = false;
@@ -822,6 +823,11 @@ public class ConfigManager {
         WalkSpeed2 = WalkSpeed2 > 5 ? 5 : WalkSpeed2;
         WalkSpeed2 = WalkSpeed2 / 5.0;
 
+        c.addComment("Global.Optimizations.ExtraProtection.HopperCrossResidenceCheck",
+                "Whether to check hoppers crossing Residence borders to prevent edge container theft (default: true)",
+                "If Flags.container is globally disabled, this option has no effect");
+        HopperCrossResidenceCheck = c.get("Global.Optimizations.ExtraProtection.HopperCrossResidenceCheck", true);
+
         SignsMaxPerResidence = c.get("Global.Signs.MaxPerResidence", 5);
         SignsMaxPerResidence = SignsMaxPerResidence < 0 ? 0 : SignsMaxPerResidence;
 
@@ -1275,6 +1281,7 @@ public class ConfigManager {
         NewPlayerRangeY = c.get("Global.NewPlayer.Range.Y", 5);
         NewPlayerRangeZ = c.get("Global.NewPlayer.Range.Z", 5);
 
+        customContainers.clear();
         c.addComment("Global.CustomContainers", "Experimental - The following settings are lists of block IDs to be used as part of the checks for the 'container' and 'use' flags when using mods.");
         List<String> pls = c.get("Global.CustomContainers", new ArrayList<String>());
         for (String one : pls) {
@@ -1283,6 +1290,7 @@ public class ConfigManager {
                 customContainers.add(mat);
         }
 
+        customBothClick.clear();
         pls = c.get("Global.CustomBothClick", new ArrayList<String>());
         for (String one : pls) {
             Material mat = CMILib.getInstance().getItemManager().getMaterial(one);
@@ -1290,6 +1298,7 @@ public class ConfigManager {
                 customBothClick.add(mat);
         }
 
+        customRightClick.clear();
         pls = c.get("Global.CustomRightClick", new ArrayList<String>());
         for (String one : pls) {
             Material mat = CMILib.getInstance().getItemManager().getMaterial(one);
@@ -2222,6 +2231,10 @@ public class ConfigManager {
 
     public List<String> getTeleportBlockedWorlds() {
         return TeleportBlockedWorlds;
+    }
+
+    public boolean getHopperCrossResidenceCheck() {
+        return HopperCrossResidenceCheck;
     }
 
 //    public int getTownMinRange() {

--- a/src/main/java/com/bekvon/bukkit/residence/ConfigManager.java
+++ b/src/main/java/com/bekvon/bukkit/residence/ConfigManager.java
@@ -490,7 +490,8 @@ public class ConfigManager {
                 "Group: default",
                 "this is the actual list of material names that this list allows or disallows",
                 "You can look up the material name by item ID in game by typing /res material <id>",
-                "Alternativly, you can simply use the item ID in the list, but its less descriptive and harder to see what the list allows or dissallows at a glance");
+                "Alternativly, you can simply use the item ID in the list, but its less descriptive and harder to see what the list allows or dissallows at a glance",
+                "Items:", "- Apple", "- Stone", "- Lava_Bucket");
 
         for (Flags fl : Flags.values()) {
             cfg.addComment("Global.FlagPermission." + fl, "Applies to: " + fl.getFlagMode(), fl.getDesc());

--- a/src/main/java/com/bekvon/bukkit/residence/Residence.java
+++ b/src/main/java/com/bekvon/bukkit/residence/Residence.java
@@ -22,8 +22,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Server;
 import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
@@ -1341,49 +1343,65 @@ public class Residence extends JavaPlugin {
         return isDisabledWorld(world.getName());
     }
 
-    public boolean isDisabledWorld(String worldname) {
-        if (!getConfigManager().EnabledWorldsList.isEmpty()) {
-            return !getConfigManager().EnabledWorldsList.contains(worldname);
+    public boolean isDisabledWorld(String worldName) {
+        if (getConfigManager().DisabledWorld) {
+            if (!getConfigManager().EnabledWorldsList.isEmpty()) {
+                return !getConfigManager().EnabledWorldsList.contains(worldName);
+            }
+            return getConfigManager().DisabledWorldsList.contains(worldName);
         }
-        return getConfigManager().DisabledWorldsList.contains(worldname);
+        return false;
     }
 
     public boolean isDisabledWorldListener(Location loc) {
+        if (loc != null && getConfigManager().DisableListeners) {
+            return isDisabledWorldListener(loc.getWorld().getName());
+        }
+        return false;
+    }
 
-        if (loc == null)
-            return false;
+    public boolean isDisabledWorldListener(Block block) {
+        if (block != null && getConfigManager().DisableListeners) {
+            return isDisabledWorldListener(block.getWorld().getName());
+        }
+        return false;
+    }
 
-        return isDisabledWorldListener(loc.getWorld().getName());
+    public boolean isDisabledWorldListener(Entity entity) {
+        if (entity != null && getConfigManager().DisableListeners) {
+            return isDisabledWorldListener(entity.getWorld().getName());
+        }
+        return false;
     }
 
     public boolean isDisabledWorldListener(World world) {
-
-        if (world == null)
-            return false;
-
-        return isDisabledWorldListener(world.getName());
+        if (world != null && getConfigManager().DisableListeners) {
+            return isDisabledWorldListener(world.getName());
+        }
+        return false;
     }
 
-    public boolean isDisabledWorldListener(String worldname) {
-
+    private boolean isDisabledWorldListener(String worldName) {
         if (!getConfigManager().EnabledWorldsList.isEmpty()) {
-            return !getConfigManager().EnabledWorldsList.contains(worldname) && getConfigManager().DisableListeners;
+            return !getConfigManager().EnabledWorldsList.contains(worldName);
         }
-
-        return getConfigManager().DisabledWorldsList.contains(worldname) && getConfigManager().DisableListeners;
+        return getConfigManager().DisabledWorldsList.contains(worldName);
     }
 
     public boolean isDisabledWorldCommand(World world) {
-        return isDisabledWorldCommand(world.getName());
+        if (getConfigManager().DisableCommands) {
+            return isDisabledWorldCommand(world.getName());
+        }
+        return false;
     }
 
-    public boolean isDisabledWorldCommand(String worldname) {
+    private boolean isDisabledWorldCommand(String worldname) {
 
         if (!getConfigManager().EnabledWorldsList.isEmpty()) {
-            return !getConfigManager().EnabledWorldsList.contains(worldname) && getConfigManager().DisableCommands;
+            return !getConfigManager().EnabledWorldsList.contains(worldname);
         }
 
-        return getConfigManager().DisabledWorldsList.contains(worldname) && getConfigManager().DisableCommands;
+        return getConfigManager().DisabledWorldsList.contains(worldname);
     }
 
     public InformationPager getInfoPageManager() {

--- a/src/main/java/com/bekvon/bukkit/residence/Residence.java
+++ b/src/main/java/com/bekvon/bukkit/residence/Residence.java
@@ -1395,13 +1395,13 @@ public class Residence extends JavaPlugin {
         return false;
     }
 
-    private boolean isDisabledWorldCommand(String worldname) {
+    private boolean isDisabledWorldCommand(String worldName) {
 
         if (!getConfigManager().EnabledWorldsList.isEmpty()) {
-            return !getConfigManager().EnabledWorldsList.contains(worldname);
+            return !getConfigManager().EnabledWorldsList.contains(worldName);
         }
 
-        return getConfigManager().DisabledWorldsList.contains(worldname);
+        return getConfigManager().DisabledWorldsList.contains(worldName);
     }
 
     public InformationPager getInfoPageManager() {

--- a/src/main/java/com/bekvon/bukkit/residence/containers/Flags.java
+++ b/src/main/java/com/bekvon/bukkit/residence/containers/Flags.java
@@ -44,7 +44,7 @@ public enum Flags {
     dragongrief(CMIMaterial.DIRT, FlagMode.Residence, "Prevents ender dragon block griefing", true),
     day(CMIMaterial.DANDELION, FlagMode.Residence, "Sets day time in residence", true),
     dye(CMIMaterial.ORANGE_DYE, FlagMode.Both, "Allows or denys sheep dyeing", true),
-    damage(CMIMaterial.GOLDEN_SWORD, FlagMode.Residence, "Allows or denys all entity damage within the residence", false),
+    damage(CMIMaterial.GOLDEN_SWORD, FlagMode.Residence, "Allow or deny damage to players and tamed animals", false),
     decay(CMIMaterial.OAK_LEAVES, FlagMode.Residence, "Allows or denys leave decay in the residence", true),
     destroy(CMIMaterial.END_STONE, FlagMode.Both, "Allows or denys only destruction of blocks, overrides the build flag", true),
     dryup(CMIMaterial.BLUE_STAINED_GLASS_PANE, FlagMode.Residence, "Prevents land from drying up", true),

--- a/src/main/java/com/bekvon/bukkit/residence/containers/Flags.java
+++ b/src/main/java/com/bekvon/bukkit/residence/containers/Flags.java
@@ -114,7 +114,7 @@ public enum Flags {
     rain(CMIMaterial.BLUE_ORCHID, FlagMode.Residence, "Sets weather to rainny in residence", true),
     respawn(CMIMaterial.SUNFLOWER, FlagMode.Residence, "Automaticaly respawns player", false),
     riding(CMIMaterial.SADDLE, FlagMode.Both, "Prevent riding a horse", true),
-    shoot(CMIMaterial.ARROW, FlagMode.Residence, "Allows or denys shooting projectile in area", true),
+    shoot(CMIMaterial.ARROW, FlagMode.Both, "Allows or denys shooting projectile in area", true),
     sun(CMIMaterial.SUNFLOWER, FlagMode.Residence, "Sets weather to sunny in residence", true),
     shop(CMIMaterial.ITEM_FRAME, FlagMode.Residence, "Adds residence to special residence shop list", true),
     snowtrail(CMIMaterial.SNOW, FlagMode.Residence, "Prevents snowman snow trails", true),

--- a/src/main/java/com/bekvon/bukkit/residence/containers/Flags.java
+++ b/src/main/java/com/bekvon/bukkit/residence/containers/Flags.java
@@ -25,7 +25,7 @@ public enum Flags {
     build(CMIMaterial.BRICKS, FlagMode.Both, "Allows or denys building", true),
     burn(CMIMaterial.TORCH, FlagMode.Residence, "Allows or denys Mob combustion in residences", true),
     button(CMIMaterial.OAK_BUTTON, FlagMode.Both, "Allows or denys players to use buttons", true),
-    boarding(CMIMaterial.ACACIA_BOAT, FlagMode.Residence, "Allows or denys animal boarding in residences", true),
+    boarding(CMIMaterial.ACACIA_BOAT, FlagMode.Residence, "Allow or deny non-player entities from riding vehicles", true),
     brush(CMIMaterial.BRUSH, FlagMode.Both, "Allows or denys block brushing", true),
     cake(CMIMaterial.CAKE, FlagMode.Both, "Allows or denys players to eat cake", true),
     canimals(CMIMaterial.SHEEP_SPAWN_EGG, FlagMode.Residence, "Allows or denys custom animal spawns", true),

--- a/src/main/java/com/bekvon/bukkit/residence/containers/Flags.java
+++ b/src/main/java/com/bekvon/bukkit/residence/containers/Flags.java
@@ -88,6 +88,7 @@ public enum Flags {
     leash(CMIMaterial.LEAD, FlagMode.Both, "Allows or denys aninal leash", true),
     lever(CMIMaterial.LEVER, FlagMode.Both, "Allows or denys players to use levers", true),
     loom(CMIMaterial.LOOM, FlagMode.Both, "Allows or denys players to use looms", true),
+    minecartsuction(CMIMaterial.HOPPER_MINECART, FlagMode.Residence, "Allow or deny derailed hopper minecarts from sucking items from containers", true),
     mobexpdrop(CMIMaterial.MELON_SEEDS, FlagMode.Residence, "Prevents mob droping exp on death", true),
     mobgriefing(CMIMaterial.BONE, FlagMode.Residence, "Allow or deny monster griefing (does not override block/entity-specific flags)", true),
     mobitemdrop(CMIMaterial.COCOA_BEANS, FlagMode.Residence, "Prevents mob droping items on death", true),

--- a/src/main/java/com/bekvon/bukkit/residence/containers/ResidencePlayer.java
+++ b/src/main/java/com/bekvon/bukkit/residence/containers/ResidencePlayer.java
@@ -422,10 +422,6 @@ public class ResidencePlayer {
         return ResidenceBlockListener.canPlaceBlock(this.getPlayer(), block, inform);
     }
 
-    public boolean canDamageEntity(Entity entity, boolean inform) {
-        return ResidenceEntityListener.canDamageEntity(this.getPlayer(), entity, inform);
-    }
-
     public Set<ClaimedResidence> getTrustedResidenceList() {
         return trustedList;
     }

--- a/src/main/java/com/bekvon/bukkit/residence/containers/lm.java
+++ b/src/main/java/com/bekvon/bukkit/residence/containers/lm.java
@@ -664,9 +664,6 @@ public enum lm {
                     }
 
                     Player player = (Player) sender;
-                    if (player.hasMetadata("NPC")) {
-                        return;
-                    }
 
                     switch (Residence.getInstance().getConfigManager().getGeneralMessageType()) {
                     case ActionBar:

--- a/src/main/java/com/bekvon/bukkit/residence/containers/lm.java
+++ b/src/main/java/com/bekvon/bukkit/residence/containers/lm.java
@@ -9,10 +9,12 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import com.bekvon.bukkit.residence.Residence;
+import com.bekvon.bukkit.residence.listenersCache.DenyMessageCache;
 
 import net.Zrips.CMILib.ActionBar.CMIActionBar;
 import net.Zrips.CMILib.Colors.CMIChatColor;
 import net.Zrips.CMILib.TitleMessages.CMITitleMessage;
+import net.Zrips.CMILib.Version.Version;
 
 public enum lm {
     Invalid_Player("&cInvalid player name..."),
@@ -611,6 +613,36 @@ public enum lm {
 
     public List<String> getMessageList() {
         return Residence.getInstance().getLM().getMessageList(this);
+    }
+
+    public void sendMessage(Player player, Flags flag) {
+        if (player == null || flag == null) {
+            return;
+        }
+        if (Version.isCurrentLower(Version.v1_16_0)) {
+            lm.Flag_Deny.sendMessage((CommandSender) player, flag);
+
+        } else {
+            int cooldownSeconds = Residence.getInstance().getConfigManager().getFlagDenyMessageCooldown();
+            if (cooldownSeconds <= 0 || DenyMessageCache.shouldSendDenyMessage(player, flag)) {
+                lm.Flag_Deny.sendMessage((CommandSender) player, flag);
+            }
+        }
+    }
+
+    public void sendMessage(Player player, Flags flag, String string) {
+        if (player == null || flag == null) {
+            return;
+        }
+        if (Version.isCurrentLower(Version.v1_16_0)) {
+            lm.Residence_FlagDeny.sendMessage((CommandSender) player, flag, string);
+
+        } else {
+            int cooldownSeconds = Residence.getInstance().getConfigManager().getFlagDenyMessageCooldown();
+            if (cooldownSeconds <= 0 || DenyMessageCache.shouldSendDenyMessage(player, flag)) {
+                lm.Residence_FlagDeny.sendMessage((CommandSender) player, flag, string);
+            }
+        }
     }
 
     public void sendMessage(CommandSender sender, Object... variables) {

--- a/src/main/java/com/bekvon/bukkit/residence/itemlist/ItemList.java
+++ b/src/main/java/com/bekvon/bukkit/residence/itemlist/ItemList.java
@@ -1,9 +1,12 @@
 package com.bekvon.bukkit.residence.itemlist;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -14,7 +17,7 @@ import net.Zrips.CMILib.Items.CMIMaterial;
 
 public class ItemList {
 
-    protected List<Material> list;
+    protected Set<Material> list;
     protected ListType type;
 
     public ItemList(ListType listType) {
@@ -23,7 +26,7 @@ public class ItemList {
     }
 
     protected ItemList() {
-        list = new ArrayList<Material>();
+        list = EnumSet.noneOf(Material.class);
     }
 
     public static enum ListType {
@@ -102,7 +105,15 @@ public class ItemList {
     protected static ItemList readList(ConfigurationSection node, ItemList list) {
         ListType type = ListType.valueOf(node.getString("Type", "").toUpperCase());
         list.type = type;
-        List<String> items = node.getStringList("Items");
+        Object itemsObj = node.get("Items");
+        List<String> items;
+        if (itemsObj instanceof List) {
+            items = node.getStringList("Items");
+        } else if (itemsObj != null) {
+            items = Collections.singletonList(String.valueOf(itemsObj));
+        } else {
+            items = Collections.emptyList();
+        }
         if (items != null) {
             for (String item : items) {
                 int parse = -1;

--- a/src/main/java/com/bekvon/bukkit/residence/itemlist/WorldItemManager.java
+++ b/src/main/java/com/bekvon/bukkit/residence/itemlist/WorldItemManager.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
 
 import net.Zrips.CMILib.Items.CMIMaterial;
 import com.bekvon.bukkit.residence.Residence;
@@ -21,23 +22,16 @@ public class WorldItemManager {
         this.plugin = plugin;
     }
 
-    public boolean isAllowed(Material mat, PermissionGroup group, String world) {
-        if (mat == null)
+    public boolean isAllowed(Material mat, Player player) {
+        if (!CMIMaterial.isValidItem(mat)) {
             return true;
-        if (group == null)
+        }
+        PermissionGroup group = plugin.getPlayerManager().getResidencePlayer(player).getGroup();
+        if (group == null) {
             return true;
-        return isAllowed(mat, group.getGroupName(), world);
-    }
-
-    public boolean isAllowed(Material mat, String group, String world) {
-        if (mat == null)
-            return true;
-
-        if (!CMIMaterial.isValidItem(mat))
-            return true;
-
+        }
         for (WorldItemList list : lists) {
-            if (!list.isAllowed(mat, world, group)) {
+            if (!list.isAllowed(mat, player.getWorld().getName(), group.getGroupName())) {
                 return false;
             }
         }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/CrackShotListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/CrackShotListener.java
@@ -3,7 +3,7 @@ package com.bekvon.bukkit.residence.listeners;
 import org.bukkit.Location;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -72,7 +72,7 @@ public class CrackShotListener implements Listener {
         // disabling event on world
         if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
-        if (event.getVictim().getType() != EntityType.ITEM_FRAME && !Utils.isArmorStandEntity(event.getVictim().getType()))
+        if (!(event.getVictim() instanceof ItemFrame) && !Utils.isArmorStand(event.getVictim()))
             return;
 
         Entity dmgr = event.getDamager();

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/CrackShotListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/CrackShotListener.java
@@ -29,7 +29,7 @@ public class CrackShotListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void AnimalKilling(WeaponDamageEntityEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         Entity damager = event.getDamager();
 
@@ -70,7 +70,7 @@ public class CrackShotListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityDamageByEntityEvent(WeaponDamageEntityEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         if (event.getVictim().getType() != EntityType.ITEM_FRAME && !Utils.isArmorStandEntity(event.getVictim().getType()))
             return;
@@ -103,7 +103,7 @@ public class CrackShotListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityDamage(WeaponDamageEntityEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         if (!(event.getVictim() instanceof Player))
             return;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
@@ -262,16 +262,43 @@ public class ResidenceBlockListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onSnowGolemTrailForm(EntityBlockFormEvent event) {
+    public void onEntityBlockForm(EntityBlockFormEvent event) {
 
-        if (FlagPermissions.shouldIgnoreCheck(Flags.snowtrail, event.getBlock())) {
+        Entity entity = event.getEntity();
+
+        if (plugin.isDisabledWorldListener(entity.getWorld())) {
             return;
         }
-        if (event.getEntity() instanceof Snowman) {
+        if (Flags.build.isGlobalyEnabled() && entity instanceof Player) {
+            Player player = (Player) entity;
+            if (FlagPermissions.shouldDenyAndNotify(player, event.getBlock(), Flags.build, null)) {
+                event.setCancelled(true);
+            }
+
+        } else if (Flags.snowtrail.isGlobalyEnabled() && entity instanceof Snowman) {
             FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
             if (!perms.has(Flags.snowtrail, true)) {
                 event.setCancelled(true);
             }
+
+        } else if (Flags.animalgriefing.isGlobalyEnabled() && Utils.isAnimal(entity)) {
+            FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
+            if (!perms.has(Flags.animalgriefing, perms.has(Flags.build, true))) {
+                event.setCancelled(true);
+            }
+
+        } else if (Flags.mobgriefing.isGlobalyEnabled() && ResidenceEntityListener.isMonster(entity)) {
+            FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
+            if (!perms.has(Flags.mobgriefing, perms.has(Flags.build, true))) {
+                event.setCancelled(true);
+            }
+
+        } else if (Flags.build.isGlobalyEnabled()) {
+            FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
+            if (!perms.has(Flags.build, true)) {
+                event.setCancelled(true);
+            }
+
         }
     }
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
@@ -1043,9 +1043,10 @@ public class ResidenceBlockListener implements Listener {
         if (!CMIMaterial.get(block.getType()).equals(CMIMaterial.TNT))
             return;
 
-        if (event.getItem() == null || !CMIMaterial.get(event.getItem()).equals(CMIMaterial.FLINT_AND_STEEL))
+        CMIMaterial held = CMIMaterial.get(event.getItem());
+        if (held != CMIMaterial.FLINT_AND_STEEL && held != CMIMaterial.FIRE_CHARGE) {
             return;
-
+        }
         Player player = event.getPlayer();
 
         if (FlagPermissions.shouldDenyAndNotify(player, block, Flags.ignite, null)) {

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
@@ -207,7 +207,7 @@ public class ResidenceBlockListener implements Listener {
             return true;
 
         // disabling event on world
-        if (Residence.getInstance().isDisabledWorldListener(loc.getWorld()))
+        if (Residence.getInstance().isDisabledWorldListener(loc))
             return true;
 
         if (ResAdmin.isResAdmin(player)) {
@@ -266,7 +266,7 @@ public class ResidenceBlockListener implements Listener {
 
         Entity entity = event.getEntity();
 
-        if (plugin.isDisabledWorldListener(entity.getWorld())) {
+        if (plugin.isDisabledWorldListener(entity)) {
             return;
         }
         if (Flags.build.isGlobalyEnabled() && entity instanceof Player) {
@@ -434,7 +434,7 @@ public class ResidenceBlockListener implements Listener {
     public void onChestPlace(BlockPlaceEvent event) {
 
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getBlock()))
             return;
         if (!plugin.getConfigManager().ShowNoobMessage())
             return;
@@ -478,7 +478,7 @@ public class ResidenceBlockListener implements Listener {
     public void onChestPlaceNearResidence(BlockPlaceEvent event) {
 
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getBlock()))
             return;
 
         Player player = event.getPlayer();
@@ -507,7 +507,7 @@ public class ResidenceBlockListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onChestPlaceCreateRes(BlockPlaceEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getBlock()))
             return;
         if (!plugin.getConfigManager().isNewPlayerUse())
             return;
@@ -547,7 +547,7 @@ public class ResidenceBlockListener implements Listener {
 
     public static boolean canPlaceBlock(Player player, Block block, boolean informPlayer) {
         // disabling event on world
-        if (Residence.getInstance().isDisabledWorldListener(block.getWorld()))
+        if (Residence.getInstance().isDisabledWorldListener(block))
             return true;
 
         if (ResAdmin.isResAdmin(player)) {
@@ -623,7 +623,7 @@ public class ResidenceBlockListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockPistonRetract(BlockPistonRetractEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getBlock()))
             return;
 
         // Disabling listener if flag disabled globally
@@ -667,7 +667,7 @@ public class ResidenceBlockListener implements Listener {
     public void onBlockPistonExtend(BlockPistonExtendEvent event) {
 
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getBlock()))
             return;
 
         // Disabling listener if flag disabled globally
@@ -732,7 +732,7 @@ public class ResidenceBlockListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockFromTo(BlockFromToEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getBlock()))
             return;
 
         ClaimedResidence fromRes = ClaimedResidence.getByLoc(event.getBlock().getLocation());
@@ -882,7 +882,7 @@ public class ResidenceBlockListener implements Listener {
     public void onLavaWaterFlow(BlockFromToEvent event) {
 
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getBlock()))
             return;
         Material mat = event.getBlock().getType();
 
@@ -1022,7 +1022,7 @@ public class ResidenceBlockListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockIgnite(BlockIgniteEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getBlock()))
             return;
 
         IgniteCause cause = event.getCause();

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
@@ -12,8 +12,6 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
-import org.bukkit.block.data.Directional;
-import org.bukkit.block.data.type.Dispenser;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -124,11 +122,10 @@ public class ResidenceBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlantGrow(BlockGrowEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.grow.isGlobalyEnabled())
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.grow, event.getBlock())) {
             return;
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
+        }
         FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
         if (!perms.has(Flags.grow, true)) {
             event.setCancelled(true);
@@ -137,16 +134,15 @@ public class ResidenceBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onVineGrow(BlockSpreadEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.grow.isGlobalyEnabled())
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.grow, event.getBlock())) {
+            return;
+        }
         CMIMaterial type = CMIMaterial.get(event.getSource().getType());
 
         if (!type.equals(CMIMaterial.VINE) && !type.toString().contains("_VINES"))
             return;
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
+
         FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
         if (!perms.has(Flags.grow, true)) {
             event.setCancelled(true);
@@ -155,11 +151,10 @@ public class ResidenceBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onleaveDecay(LeavesDecayEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.decay.isGlobalyEnabled())
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.decay, event.getBlock())) {
             return;
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
+        }
         FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
         if (!perms.has(Flags.decay, true)) {
             event.setCancelled(true);
@@ -168,11 +163,10 @@ public class ResidenceBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onTreeGrowt(StructureGrowEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.grow.isGlobalyEnabled())
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.grow, event.getWorld())) {
             return;
-        if (plugin.isDisabledWorldListener(event.getWorld()))
-            return;
+        }
         FlagPermissions perms = FlagPermissions.getPerms(event.getLocation());
         if (!perms.has(Flags.grow, true)) {
             event.setCancelled(true);
@@ -269,13 +263,10 @@ public class ResidenceBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onSnowGolemTrailForm(EntityBlockFormEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.snowtrail.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.snowtrail, event.getBlock())) {
+            return;
+        }
         if (event.getEntity() instanceof Snowman) {
             FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
             if (!perms.has(Flags.snowtrail, true)) {
@@ -298,12 +289,10 @@ public class ResidenceBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onIceForm(BlockFormEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.iceform.isGlobalyEnabled())
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.iceform, event.getBlock())) {
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
+        }
         // SnowGolem already has SnowTrail Flag
         if (event instanceof EntityBlockFormEvent
                 && ((EntityBlockFormEvent) event).getEntity() instanceof Snowman) {
@@ -320,13 +309,10 @@ public class ResidenceBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onIceMelt(BlockFadeEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.icemelt.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.icemelt, event.getBlock())) {
+            return;
+        }
         if (!isIceOrSnow(event.getBlock().getType())) {
             return;
         }
@@ -386,12 +372,10 @@ public class ResidenceBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockFall(EntityChangeBlockEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.fallinprotection.isGlobalyEnabled())
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.fallinprotection, event.getBlock())) {
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
+        }
         if (!plugin.getConfigManager().isBlockFall())
             return;
 
@@ -598,12 +582,10 @@ public class ResidenceBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockSpread(BlockSpreadEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.spread.isGlobalyEnabled())
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.spread, event.getBlock())) {
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
+        }
         Location loc = event.getBlock().getLocation();
         FlagPermissions perms = FlagPermissions.getPerms(loc);
         if (!perms.has(Flags.spread, true)) {
@@ -763,13 +745,10 @@ public class ResidenceBlockListener implements Listener {
         // Moved to separate class
         if (Version.isCurrentEqualOrHigher(Version.v1_13_R1))
             return;
-        // Disabling listener if flag disabled globally
-        if (!Flags.dryup.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.dryup, event.getBlock())) {
+            return;
+        }
         CMIMaterial mat = CMIMaterial.get(event.getBlock());
         if (!mat.equals(CMIMaterial.FARMLAND))
             return;
@@ -795,13 +774,10 @@ public class ResidenceBlockListener implements Listener {
         // Moved to separate class
         if (Version.isCurrentEqualOrHigher(Version.v1_13_R1))
             return;
-        // Disabling listener if flag disabled globally
-        if (!Flags.dryup.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.dryup, event.getBlock())) {
+            return;
+        }
         if (!event.getBlock().getWorld().isChunkLoaded((int) Math.floor(event.getBlock().getLocation().getX()) >> 4, ((int) Math.floor(event.getBlock().getLocation().getZ()) >> 4)))
             return;
 
@@ -827,17 +803,14 @@ public class ResidenceBlockListener implements Listener {
     @SuppressWarnings("removal")
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onDispense(BlockDispenseEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.build.isGlobalyEnabled())
-            return;
 
         Block block = event.getBlock();
         if (block == null)
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.build, block)) {
+            return;
+        }
         if (CMIMaterial.get(block.getType()) != CMIMaterial.DISPENSER)
             return;
 
@@ -913,12 +886,10 @@ public class ResidenceBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockBurn(BlockBurnEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.firespread.isGlobalyEnabled())
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.firespread, event.getBlock())) {
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
+        }
         FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
         if (!perms.has(Flags.firespread, true))
             event.setCancelled(true);
@@ -926,16 +897,12 @@ public class ResidenceBlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onBlockBurn(PortalCreateEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.build.isGlobalyEnabled())
-            return;
 
         World world = event.getWorld();
 
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(world))
+        if (FlagPermissions.shouldIgnoreCheck(Flags.build, world)) {
             return;
-
+        }
         if (!event.getReason().toString().equals("NETHER_PAIR"))
             return;
 
@@ -1062,17 +1029,14 @@ public class ResidenceBlockListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onInteractTNT(PlayerInteractEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.ignite.isGlobalyEnabled())
-            return;
 
         Block block = event.getClickedBlock();
         if (block == null)
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.ignite, block)) {
+            return;
+        }
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK)
             return;
 
@@ -1084,14 +1048,8 @@ public class ResidenceBlockListener implements Listener {
 
         Player player = event.getPlayer();
 
-        if (player.hasMetadata("NPC") || ResAdmin.isResAdmin(player))
-            return;
-
-        if (FlagPermissions.has(block.getLocation(), player, Flags.ignite, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.ignite);
-        event.setCancelled(true);
-
+        if (FlagPermissions.shouldDenyAndNotify(player, block, Flags.ignite, null)) {
+            event.setCancelled(true);
+        }
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceBlockListener.java
@@ -16,6 +16,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Snowman;
+import org.bukkit.entity.minecart.HopperMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -38,11 +39,13 @@ import org.bukkit.event.block.EntityBlockFormEvent;
 import org.bukkit.event.block.LeavesDecayEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.world.PortalCreateEvent;
 import org.bukkit.event.world.StructureGrowEvent;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.util.Vector;
@@ -1079,5 +1082,77 @@ public class ResidenceBlockListener implements Listener {
         if (FlagPermissions.shouldDenyAndNotify(player, block, Flags.ignite, null)) {
             event.setCancelled(true);
         }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onHopperMoveItem(InventoryMoveItemEvent event) {
+        // Prevent trolls from pushing derailed hopper minecarts into the Residence to steal items from containers
+        if (Flags.minecartsuction.isGlobalyEnabled()) {
+            InventoryHolder holder = event.getInitiator().getHolder();
+            if (holder instanceof HopperMinecart) {
+                Location loc = ((HopperMinecart) holder).getLocation();
+                if (!CMIMaterial.get(loc.getBlock().getType()).containsCriteria(CMIMC.RAIL)
+                        && FlagPermissions.has(loc, Flags.minecartsuction, FlagCombo.OnlyFalse)) {
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+        }
+        // Protect containers at the edge of the Residence area from theft
+        if (!Flags.container.isGlobalyEnabled() || !plugin.getConfigManager().getHopperCrossResidenceCheck()) {
+            return;
+        }
+        Location sourceLoc = null;
+        Location destLoc = null;
+
+        if (Version.isCurrentEqualOrHigher(Version.v1_9_0)) {
+            sourceLoc= event.getSource().getLocation();
+            destLoc = event.getDestination().getLocation();
+
+            // Legacy versions do not support Inventory.getLocation() directly
+        } else {
+            InventoryHolder sourceHolder = event.getSource().getHolder();
+            if (sourceHolder instanceof BlockState) {
+                sourceLoc = ((BlockState) sourceHolder).getLocation();
+            } else if (sourceHolder instanceof Entity) {
+                sourceLoc = ((Entity) sourceHolder).getLocation();
+            }
+
+            InventoryHolder destHolder = event.getDestination().getHolder();
+            if (destHolder instanceof BlockState) {
+                destLoc = ((BlockState) destHolder).getLocation();
+            } else if (destHolder instanceof Entity) {
+                destLoc = ((Entity) destHolder).getLocation();
+            }
+        }
+        ClaimedResidence sourceRes = ClaimedResidence.getByLoc(sourceLoc);
+        ClaimedResidence destRes = ClaimedResidence.getByLoc(destLoc);
+        // Source and Dest not in Res
+        if (sourceRes == null && destRes == null) {
+            return;
+        }
+        // Source and Dest in Res
+        if (sourceRes != null && destRes != null) {
+            // in Same Res, or have Same Res owner
+            if (sourceRes == destRes || sourceRes.isOwner(destRes.getOwner())) {
+                return;
+            }
+            // Not in Same Res and not Same Res owner; hopper can be Source or Dest
+            if (sourceRes.getPermissions().has(Flags.container, true)
+                    && destRes.getPermissions().has(Flags.container, true)) {
+                return;
+            }
+            // Source in Res, Dest definitely not in Res
+        } else if (sourceRes != null) {
+            if (sourceRes.getPermissions().has(Flags.container, true)) {
+                return;
+            }
+            // Dest definitely in Res, Source definitely not in Res
+        } else {
+            if (destRes.getPermissions().has(Flags.container, true)) {
+                return;
+            }
+        }
+        event.setCancelled(true);
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
@@ -10,7 +10,6 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Arrow;
-import org.bukkit.entity.Animals;
 import org.bukkit.entity.Boat;
 import org.bukkit.entity.Creeper;
 import org.bukkit.entity.EnderCrystal;
@@ -107,7 +106,7 @@ public class ResidenceEntityListener implements Listener {
     public void onEntityChangeBlock(EntityChangeBlockEvent event) {
         Block block = event.getBlock();
         // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld())) {
+        if (plugin.isDisabledWorldListener(block)) {
             return;
         }
         Entity entity = event.getEntity();
@@ -205,7 +204,7 @@ public class ResidenceEntityListener implements Listener {
             return;
 
         // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
+        if (plugin.isDisabledWorldListener(entity))
             return;
 
         FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation());
@@ -220,7 +219,7 @@ public class ResidenceEntityListener implements Listener {
 
         Entity entity = event.getEntity();
         // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld())) {
+        if (plugin.isDisabledWorldListener(entity)) {
             return;
         }
         Block block = event.getBlock();
@@ -496,7 +495,7 @@ public class ResidenceEntityListener implements Listener {
         LivingEntity ent = event.getEntity();
         if (ent == null)
             return;
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
+        if (plugin.isDisabledWorldListener(ent))
             return;
         if (ent instanceof Player)
             return;
@@ -676,7 +675,7 @@ public class ResidenceEntityListener implements Listener {
         Entity ent = event.getEntity();
         if (ent == null)
             return;
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
+        if (plugin.isDisabledWorldListener(ent))
             return;
         FlagPermissions perms = FlagPermissions.getPerms(event.getLocation());
         if (Utils.isAnimal(ent)) {
@@ -786,7 +785,7 @@ public class ResidenceEntityListener implements Listener {
     public void onProjectileLaunch(ProjectileLaunchEvent event) {
         Projectile projectile = event.getEntity();
         // disabling event on world
-        if (plugin.isDisabledWorldListener(projectile.getWorld())) {
+        if (plugin.isDisabledWorldListener(projectile)) {
             return;
         }
         Flags flag = Flags.shoot;
@@ -936,7 +935,7 @@ public class ResidenceEntityListener implements Listener {
         Entity ent = event.getEntity();
         if (ent == null)
             return;
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
+        if (plugin.isDisabledWorldListener(ent))
             return;
 
         CMIEntityType type = CMIEntityType.get(event.getEntityType());
@@ -1049,7 +1048,7 @@ public class ResidenceEntityListener implements Listener {
         }
         // disabling event on world
         Location loc = event.getLocation();
-        if (plugin.isDisabledWorldListener(loc.getWorld()))
+        if (plugin.isDisabledWorldListener(loc))
             return;
 
         Entity ent = event.getEntity();
@@ -1484,7 +1483,7 @@ public class ResidenceEntityListener implements Listener {
     public void onEntityDamageByEntityEvent(EntityDamageByEntityEvent event) {
         Entity entity = event.getEntity();
         // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
+        if (plugin.isDisabledWorldListener(entity))
             return;
 
         if (!(entity instanceof EnderCrystal) && !(entity instanceof ItemFrame)
@@ -1719,7 +1718,7 @@ public class ResidenceEntityListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityDamage(EntityDamageEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getEntity()))
             return;
         Entity ent = event.getEntity();
         if (ent.hasMetadata("NPC"))

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
@@ -112,9 +112,8 @@ public class ResidenceEntityListener implements Listener {
         }
         Entity entity = event.getEntity();
         boolean shouldDeny = false;
-        // Use Bukkit's Animals and Monster interfaces
-        // should cover the entities that trigger EntityChangeBlockEvent
-        if (Flags.animalgriefing.isGlobalyEnabled() && entity instanceof Animals) {
+
+        if (Flags.animalgriefing.isGlobalyEnabled() && Utils.isAnimal(entity)) {
             // Animals are friendly (villagers farming/sheep grazing)
             // When Flags.animalgriefing is None, do not fall back to Flags.destroy
             shouldDeny = FlagPermissions.has(block.getLocation(), Flags.animalgriefing, FlagCombo.OnlyFalse);
@@ -123,7 +122,7 @@ public class ResidenceEntityListener implements Listener {
             FlagPermissions perms = FlagPermissions.getPerms(block.getLocation());
             shouldDeny = !perms.has(Flags.witherdestruction, perms.has(Flags.destroy, true));
 
-        } else if (Flags.mobgriefing.isGlobalyEnabled() && entity instanceof Monster) {
+        } else if (Flags.mobgriefing.isGlobalyEnabled() && isMonster(entity)) {
             FlagPermissions perms = FlagPermissions.getPerms(block.getLocation());
             shouldDeny = !perms.has(Flags.mobgriefing, perms.has(Flags.destroy, true));
 
@@ -152,6 +151,10 @@ public class ResidenceEntityListener implements Listener {
 
         } else if (Flags.brush.isGlobalyEnabled() && (mat == CMIMaterial.SUSPICIOUS_GRAVEL || mat == CMIMaterial.SUSPICIOUS_SAND)) {
             flag = Flags.brush;
+
+        } else if (Flags.build.isGlobalyEnabled()) {
+            // by default, future player-triggered EntityChangeBlockEvent mechanisms check Flags.build
+            flag = Flags.build;
 
         } else {
             return false;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
@@ -75,7 +75,6 @@ import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 import com.bekvon.bukkit.residence.utils.Utils;
 
 import net.Zrips.CMILib.ActionBar.CMIActionBar;
-import net.Zrips.CMILib.Entities.CMIEntity;
 import net.Zrips.CMILib.Entities.CMIEntityType;
 import net.Zrips.CMILib.Items.CMIMC;
 import net.Zrips.CMILib.Items.CMIMaterial;
@@ -158,15 +157,7 @@ public class ResidenceEntityListener implements Listener {
         } else {
             return false;
         }
-        if (player.hasMetadata("NPC") || ResAdmin.isResAdmin(player)) {
-            return false;
-        }
-        FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
-        if (!perms.playerHas(player, flag, perms.playerHas(player, Flags.build, true))) {
-            lm.Flag_Deny.sendMessage(player, flag);
-            return true;
-        }
-        return false;
+        return FlagPermissions.shouldDenyAndNotify(player, block, flag, Flags.build);
     }
 
     private boolean shouldDenyBoatBreakLilyPad(Boat boat, Block block) {
@@ -376,16 +367,13 @@ public class ResidenceEntityListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void AnimalKilling(EntityDamageEvent event) {
 
-        // Disabling listener if flag disabled globally
-        if (!Flags.animalkilling.isGlobalyEnabled())
-            return;
         Entity entity = event.getEntity();
         if (entity == null)
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.animalkilling, entity)) {
+            return;
+        }
         if (!Utils.isAnimal(entity))
             return;
 
@@ -428,18 +416,17 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void AnimalKillingByFlame(EntityCombustByEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.animalkilling.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
-            return;
+
         if (event.isCancelled())
             return;
 
         Entity entity = event.getEntity();
         if (entity == null)
             return;
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.animalkilling, entity)) {
+            return;
+        }
         if (!Utils.isAnimal(entity))
             return;
 
@@ -472,18 +459,17 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void AnimalDamageByMobs(EntityDamageByEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.animalkilling.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
-            return;
+
         if (event.isCancelled())
             return;
 
         Entity entity = event.getEntity();
         if (entity == null)
             return;
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.animalkilling, entity)) {
+            return;
+        }
         if (!Utils.isAnimal(entity))
             return;
 
@@ -525,18 +511,13 @@ public class ResidenceEntityListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void VehicleDestroy(VehicleDestroyEvent event) {
 
-        // Disabling listener if flag disabled globally
-        if (!Flags.vehicledestroy.isGlobalyEnabled())
-            return;
-
-        // disabling event on world
         Entity damager = event.getAttacker();
         if (damager == null)
             return;
 
-        if (plugin.isDisabledWorldListener(damager.getWorld()))
+        if (FlagPermissions.shouldIgnoreCheck(Flags.vehicledestroy, damager)) {
             return;
-
+        }
         Vehicle vehicle = event.getVehicle();
 
         if (shouldBlockVehicleDestroy(damager, vehicle))
@@ -546,18 +527,13 @@ public class ResidenceEntityListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void vehicleCombust(EntityCombustByEntityEvent event) {
 
-        // Disabling listener if flag disabled globally
-        if (!Flags.vehicledestroy.isGlobalyEnabled())
-            return;
-
-        // disabling event on world
         Entity damager = event.getCombuster();
         if (damager == null)
             return;
 
-        if (plugin.isDisabledWorldListener(damager.getWorld()))
+        if (FlagPermissions.shouldIgnoreCheck(Flags.vehicledestroy, damager)) {
             return;
-
+        }
         if (!(event.getEntity() instanceof Vehicle))
             return;
 
@@ -578,34 +554,23 @@ public class ResidenceEntityListener implements Listener {
         Player cause = Utils.potentialProjectileToPlayer(damager);
 
         if (cause != null) {
+            return FlagPermissions.shouldDenyAndNotify(cause, vehicle, Flags.vehicledestroy, null);
 
-            if (ResAdmin.isResAdmin(cause))
-                return false;
-
-            if (FlagPermissions.has(vehicle.getLocation(), cause, Flags.vehicledestroy, FlagCombo.OnlyFalse)) {
-                lm.Flag_Deny.sendMessage(cause, Flags.vehicledestroy);
-                return true;
-            }
-
-        } else if (FlagPermissions.has(vehicle.getLocation(), Flags.vehicledestroy, FlagCombo.OnlyFalse)) {
-            return true;
+        } else {
+            return FlagPermissions.has(vehicle.getLocation(), Flags.vehicledestroy, FlagCombo.OnlyFalse);
         }
-        return false;
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void MonsterKilling(EntityDamageByEntityEvent event) {
 
-        // Disabling listener if flag disabled globally
-        if (!Flags.mobkilling.isGlobalyEnabled())
-            return;
-        // disabling event on world
         Entity entity = event.getEntity();
         if (entity == null)
             return;
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.mobkilling, entity)) {
+            return;
+        }
         if (!isMonster(entity))
             return;
 
@@ -622,80 +587,54 @@ public class ResidenceEntityListener implements Listener {
         if (cause == null)
             return;
 
-        if (ResAdmin.isResAdmin(cause))
-            return;
-
-        if (FlagPermissions.has(entity.getLocation(), cause, Flags.mobkilling, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(cause, Flags.mobkilling);
-        event.setCancelled(true);
+        if (FlagPermissions.shouldDenyAndNotify(cause, entity, Flags.mobkilling, null)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void PlayerLeashEntityEvent(PlayerLeashEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.leash.isGlobalyEnabled())
-            return;
 
         Entity entity = event.getEntity();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.leash, entity)) {
+            return;
+        }
         Player player = event.getPlayer();
 
-        if (ResAdmin.isResAdmin(player))
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation(), player);
-        if (perms.playerHas(player, Flags.leash, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.leash);
-
-        event.setCancelled(true);
+        if (FlagPermissions.shouldDenyAndNotify(player, entity, Flags.leash, null)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onFenceLeashInteract(PlayerInteractEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.leash.isGlobalyEnabled())
-            return;
 
         Entity entity = event.getRightClicked();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.leash, entity)) {
+            return;
+        }
         if (CMIEntityType.get(entity.getType()) != CMIEntityType.LEASH_KNOT)
             return;
 
         Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player))
-            return;
 
-        FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation(), player);
-        if (perms.playerHas(player, Flags.leash, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.leash);
-
-        event.setCancelled(true);
+        if (FlagPermissions.shouldDenyAndNotify(player, entity, Flags.leash, null)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onWitherSpawn(CreatureSpawnEvent event) {
 
-        // Disabling listener if flag disabled globally
-        if (!Flags.witherspawn.isGlobalyEnabled())
-            return;
-        // disabling event on world
         Entity ent = event.getEntity();
         if (ent == null)
             return;
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.witherspawn, ent)) {
             return;
+        }
 
         if (ent.getType() != EntityType.WITHER)
             return;
@@ -711,16 +650,14 @@ public class ResidenceEntityListener implements Listener {
     public void onPhantomSpawn(CreatureSpawnEvent event) {
         if (Version.isCurrentLower(Version.v1_13_R1))
             return;
-        // Disabling listener if flag disabled globally
-        if (!Flags.phantomspawn.isGlobalyEnabled())
-            return;
-        // disabling event on world
+
         Entity ent = event.getEntity();
         if (ent == null)
             return;
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.phantomspawn, ent)) {
+            return;
+        }
         if (ent.getType() != EntityType.PHANTOM)
             return;
 
@@ -829,22 +766,16 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onHangingPlace(HangingPlaceEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.place.isGlobalyEnabled())
-            return;
-        // disabling event on world
+
         Player player = event.getPlayer();
         if (player == null)
             return;
-        if (plugin.isDisabledWorldListener(player.getWorld()))
-            return;
-        if (ResAdmin.isResAdmin(player))
-            return;
 
-        FlagPermissions perms = FlagPermissions.getPerms(event.getEntity().getLocation(), player);
-        if (!perms.playerHas(player, Flags.place, perms.playerHas(player, Flags.build, true))) {
+        if (FlagPermissions.shouldIgnoreCheck(Flags.place, player)) {
+            return;
+        }
+        if (FlagPermissions.shouldDenyAndNotify(player, event.getEntity(), Flags.place, Flags.build)) {
             event.setCancelled(true);
-            lm.Flag_Deny.sendMessage(player, Flags.place);
             player.updateInventory();
         }
     }
@@ -881,12 +812,7 @@ public class ResidenceEntityListener implements Listener {
         if (shooter instanceof Player) {
 
             Player player = (Player) shooter;
-            if (player.hasMetadata("NPC") || ResAdmin.isResAdmin(player)) {
-                return;
-            }
-            FlagPermissions perms = FlagPermissions.getPerms(projectile.getLocation(), player);
-            if (perms.playerHas(player, flag, FlagCombo.OnlyFalse)) {
-                lm.Flag_Deny.sendMessage(player, flag);
+            if (FlagPermissions.shouldDenyAndNotify(player, projectile, flag, null)) {
                 event.setCancelled(true);
             }
 
@@ -900,45 +826,37 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onHangingBreak(HangingBreakByEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.destroy.isGlobalyEnabled())
-            return;
-        // disabling event on world
+
         Hanging ent = event.getEntity();
         if (ent == null)
             return;
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.destroy, ent)) {
+            return;
+        }
         if (!(event.getRemover() instanceof Player))
             return;
 
         Player player = (Player) event.getRemover();
-        if (ResAdmin.isResAdmin(player))
-            return;
 
         if (plugin.getResidenceManager().isOwnerOfLocation(player, ent.getLocation()))
             return;
 
-        FlagPermissions perms = FlagPermissions.getPerms(ent.getLocation(), player);
-        if (!perms.playerHas(player, Flags.destroy, perms.playerHas(player, Flags.build, true))) {
+        if (FlagPermissions.shouldDenyAndNotify(player, ent, Flags.destroy, Flags.build)) {
             event.setCancelled(true);
-            lm.Flag_Deny.sendMessage(player, Flags.destroy);
         }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onHangingBreakEventByExplosion(HangingBreakEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.explode.isGlobalyEnabled())
-            return;
-        // disabling event on world
+
         Hanging ent = event.getEntity();
         if (ent == null)
             return;
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.explode, ent)) {
+            return;
+        }
         if (!event.getCause().equals(RemoveCause.EXPLOSION))
             return;
 
@@ -950,15 +868,14 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onHangingBreakEvent(HangingBreakEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.destroy.isGlobalyEnabled())
-            return;
-        // disabling event on world
+
         Hanging ent = event.getEntity();
         if (ent == null)
             return;
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.destroy, ent)) {
             return;
+        }
         // ItemFrame covers item_frame/glow_item_frame
         if (!(ent instanceof ItemFrame)) {
             return;
@@ -974,16 +891,14 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onHangingBreakByEntity(HangingBreakByEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.destroy.isGlobalyEnabled())
-            return;
-        // disabling event on world
+
         Hanging ent = event.getEntity();
         if (ent == null)
             return;
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.destroy, ent)) {
+            return;
+        }
         if (event.getRemover() instanceof Player)
             return;
 
@@ -999,15 +914,14 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityCombust(EntityCombustEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.burn.isGlobalyEnabled())
-            return;
-        // disabling event on world
+
         Entity ent = event.getEntity();
         if (ent == null)
             return;
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.burn, ent)) {
             return;
+        }
         FlagPermissions perms = FlagPermissions.getPerms(ent.getLocation());
         if (!perms.has(Flags.burn, true)) {
             event.setCancelled(true);
@@ -1391,15 +1305,12 @@ public class ResidenceEntityListener implements Listener {
     // Various zombies break the door
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityBreakDoor(EntityBreakDoorEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.mobgriefing.isGlobalyEnabled())
-            return;
 
         Block block = event.getBlock();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.mobgriefing, block)) {
+            return;
+        }
         FlagPermissions perms = FlagPermissions.getPerms(block.getLocation());
         if (perms.has(Flags.mobgriefing, perms.has(Flags.destroy, true))) {
             return;
@@ -1410,13 +1321,10 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onSplashPotion(PotionSplashEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.pvp.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.pvp, event.getEntity())) {
+            return;
+        }
         ProjectileSource shooter = event.getPotion().getShooter();
 
         if (shooter instanceof Witch)
@@ -1482,15 +1390,11 @@ public class ResidenceEntityListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void PlayerKillingByFlame(EntityCombustByEntityEvent event) {
 
-        // Disabling listener if flag disabled globally
-        if (!Flags.pvp.isGlobalyEnabled())
-            return;
-
         Entity entity = event.getEntity();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.pvp, entity)) {
+            return;
+        }
         if (!(entity instanceof Player))
             return;
 
@@ -1521,13 +1425,9 @@ public class ResidenceEntityListener implements Listener {
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void OnFallDamage(EntityDamageEvent event) {
 
-        // Disabling listener if flag disabled globally
-        if (!Flags.falldamage.isGlobalyEnabled())
+        if (FlagPermissions.shouldIgnoreCheck(Flags.falldamage, event.getEntity())) {
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
-            return;
-
+        }
         if (event.getCause() != DamageCause.FALL)
             return;
         Entity ent = event.getEntity();
@@ -1541,15 +1441,12 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void OnArmorStandFlameDamage(EntityDamageEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.destroy.isGlobalyEnabled())
-            return;
 
         Entity ent = event.getEntity();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.destroy, ent)) {
+            return;
+        }
         if (event.getCause() != DamageCause.FIRE_TICK)
             return;
 
@@ -1564,15 +1461,12 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void OnArmorStandExplosion(EntityDamageEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.destroy.isGlobalyEnabled())
-            return;
 
         Entity ent = event.getEntity();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.destroy, ent)) {
+            return;
+        }
         if (event.getCause() != DamageCause.BLOCK_EXPLOSION && event.getCause() != DamageCause.ENTITY_EXPLOSION)
             return;
 
@@ -1587,13 +1481,10 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityCatchingFire(EntityDamageByEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.pvp.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.pvp, event.getEntity())) {
+            return;
+        }
         if (!damageableProjectile(event.getDamager()))
             return;
 
@@ -1610,13 +1501,10 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void OnPlayerDamageByLightning(EntityDamageEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.pvp.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.pvp, event.getEntity())) {
+            return;
+        }
         if (event.getCause() != DamageCause.LIGHTNING)
             return;
         Entity ent = event.getEntity();
@@ -1628,13 +1516,10 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityDamageByFireballEvent(EntityDamageByEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.fireball.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.fireball, event.getEntity())) {
+            return;
+        }
         Entity dmgr = event.getDamager();
         if (dmgr.getType() != EntityType.SMALL_FIREBALL && dmgr.getType() != EntityType.FIREBALL)
             return;
@@ -1648,13 +1533,10 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityDamageByWitherEvent(EntityDamageByEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.witherdamage.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.witherdamage, event.getEntity())) {
+            return;
+        }
         Entity dmgr = event.getDamager();
         if (dmgr.getType() != EntityType.WITHER && dmgr.getType() != EntityType.WITHER_SKULL)
             return;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
@@ -61,7 +61,6 @@ import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.projectiles.ProjectileSource;
-import org.jetbrains.annotations.Nullable;
 
 import com.bekvon.bukkit.residence.ConfigManager;
 import com.bekvon.bukkit.residence.Residence;
@@ -1019,18 +1018,9 @@ public class ResidenceEntityListener implements Listener {
                 ent.remove();
             }
             break;
+        // These entity explosions are handled by EntityExplodeEvent
         case BREEZE_WIND_CHARGE:
         case WIND_CHARGE:
-            if (!Flags.windexplode.isGlobalyEnabled()) {
-                break;
-            }
-            ProjectileSource shooter = ((Projectile) ent).getShooter();
-            // Allow sending deny message
-            if (shouldDenyWindChargeExplode(ent.getLocation(), shooter, perms, Flags.windexplode, Flags.explode, true)) {
-                event.setCancelled(true);
-                ent.remove();
-            }
-            break;
         case WITHER:
             break;
         default:
@@ -1040,58 +1030,20 @@ public class ResidenceEntityListener implements Listener {
             }
             if (!perms.has(Flags.explode, perms.has(Flags.destroy, true))) {
                 event.setCancelled(true);
-                ent.remove();
             }
             break;
         }
     }
 
-    private boolean shouldDenyWindChargeExplode(Location triggerLoc, ProjectileSource shooter, FlagPermissions perms,
-                                                Flags mainFlag, Flags subFlag, boolean sendDenyMessage) {
-        boolean sholudDeny = false;
-        if (shooter instanceof Player) {
-            Player player = (Player) shooter;
-            if (player.hasMetadata("NPC") || ResAdmin.isResAdmin(player)) {
-                return false;
-            }
-            FlagPermissions playerPerms = FlagPermissions.getPerms(triggerLoc, player);
-            // Because Flags.explode is not FlagMode.Both
-            boolean result = (subFlag == Flags.explode)
-                    ? perms.has(subFlag, true)
-                    : playerPerms.playerHas(player, subFlag, true);
-            if (!playerPerms.playerHas(player, mainFlag, result)) {
-                if (sendDenyMessage){
-                    lm.Flag_Deny.sendMessage(player, mainFlag);
-                }
-                sholudDeny = true;
-            }
-        } else {
-            if (!perms.has(mainFlag, perms.has(subFlag, true))) {
-                sholudDeny = true;
-            }
-        }
-        return sholudDeny;
-    }
-
-    @Nullable
-    private static Flags getWindChargeExplodeInteractBlockFlag(Block block) {
-        Flags flag = null;
-        CMIMaterial mat = CMIMaterial.get(block.getType());
-        if (mat.containsCriteria(CMIMC.BUTTON)) {
-            flag = Flags.button;
-        } else if (mat.containsCriteria(CMIMC.DOOR) || mat.containsCriteria(CMIMC.FENCEGATE) || mat.containsCriteria(CMIMC.TRAPDOOR)) {
-            flag = Flags.door;
-        } else if (mat == CMIMaterial.BELL || mat.containsCriteria(CMIMC.CANDLE) || mat.containsCriteria(CMIMC.CANDLECAKE)) {
-            flag = Flags.use;
-        } else if (mat == CMIMaterial.LEVER) {
-            flag = Flags.lever;
-        }
-        return flag;
-    }
-
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityExplode(EntityExplodeEvent event) {
-
+        // ExplosionResult.TRIGGER_BLOCK does not destroy blocks
+        // it is triggered by (WindCharge and Wind Charged Effect)
+        if (Version.isCurrentEqualOrHigher(Version.v1_21_0)
+                && event.getExplosionResult() == org.bukkit.ExplosionResult.TRIGGER_BLOCK) {
+            ResidenceListener1_21.onWindExplode(event);
+            return;
+        }
         // disabling event on world
         Location loc = event.getLocation();
         if (plugin.isDisabledWorldListener(loc.getWorld()))
@@ -1109,17 +1061,6 @@ public class ResidenceEntityListener implements Listener {
         if (ent != null && ctype != null) {
 
             switch (ctype) {
-            case BREEZE_WIND_CHARGE:
-            case WIND_CHARGE:
-                shooter = ((Projectile) ent).getShooter();
-                if (!Flags.windexplode.isGlobalyEnabled()) {
-                    break;
-                }
-                // Allow sending deny message
-                if (shouldDenyWindChargeExplode(loc, shooter, perms, Flags.windexplode, Flags.explode, true)) {
-                    cancel = true;
-                }
-                break;
             case CREEPER:
                 // Disabling listener if flag disabled globally
                 if (!Flags.creeper.isGlobalyEnabled())
@@ -1211,18 +1152,6 @@ public class ResidenceEntityListener implements Listener {
 
             if (ent != null && ctype != null) {
                 switch (ctype) {
-                case BREEZE_WIND_CHARGE:
-                case WIND_CHARGE:
-                    // Wind Charge explosions don't destroy blocks, only interact with specific ones
-                    Flags flag = getWindChargeExplodeInteractBlockFlag(block);
-                    if (flag == null || !flag.isGlobalyEnabled()) {
-                        continue;
-                    }
-                    // Deny sending deny message – too many interacted blocks
-                    if (shouldDenyWindChargeExplode(block.getLocation(), shooter, blockperms, flag, Flags.use, false)) {
-                        preserve.add(block);
-                    }
-                    continue;
                 case CREEPER:
                     // Disabling listener if flag disabled globally
                     if (!Flags.creeper.isGlobalyEnabled())
@@ -1297,8 +1226,8 @@ public class ResidenceEntityListener implements Listener {
             }
         }
 
-        for (Block block : preserve) {
-            event.blockList().remove(block);
+        if (!preserve.isEmpty()) {
+            event.blockList().removeAll(preserve);
         }
     }
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
@@ -144,21 +144,23 @@ public class ResidenceEntityListener implements Listener {
 
     private boolean shouldDenyPlayerChangeBlock(Block block, Player player) {
         CMIMaterial mat = CMIMaterial.get(block.getType());
-        Flags flag;
+        Flags mainFlag;
+        Flags subFlag = Flags.build;
         if (Flags.copper.isGlobalyEnabled() && mat.containsCriteria(CMIMC.COPPER)) {
-            flag = Flags.copper;
+            mainFlag = Flags.copper;
 
         } else if (Flags.brush.isGlobalyEnabled() && (mat == CMIMaterial.SUSPICIOUS_GRAVEL || mat == CMIMaterial.SUSPICIOUS_SAND)) {
-            flag = Flags.brush;
+            mainFlag = Flags.brush;
 
         } else if (Flags.build.isGlobalyEnabled()) {
             // by default, future player-triggered EntityChangeBlockEvent mechanisms check Flags.build
-            flag = Flags.build;
+            mainFlag = Flags.build;
+            subFlag = null;
 
         } else {
             return false;
         }
-        return FlagPermissions.shouldDenyAndNotify(player, block, flag, Flags.build);
+        return FlagPermissions.shouldDenyAndNotify(player, block, mainFlag, subFlag);
     }
 
     private boolean shouldDenyBoatBreakLilyPad(Boat boat, Block block) {

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
@@ -23,11 +23,14 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
-import org.bukkit.entity.Tameable;
+import org.bukkit.entity.Snowball;
+import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.entity.Witch;
 import org.bukkit.entity.Wither;
+import org.bukkit.entity.WitherSkull;
+import org.bukkit.entity.minecart.ExplosiveMinecart;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -53,9 +56,7 @@ import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.hanging.HangingBreakEvent.RemoveCause;
 import org.bukkit.event.hanging.HangingPlaceEvent;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.vehicle.VehicleDestroyEvent;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.potion.PotionEffect;
@@ -348,10 +349,6 @@ public class ResidenceEntityListener implements Listener {
         return false;
     }
 
-    private static boolean isTamed(Entity ent) {
-        return ent instanceof Tameable && ((Tameable) ent).isTamed();
-    }
-
     private static boolean damageableProjectile(Entity ent) {
         if (ent instanceof Projectile && CMIEntityType.get(ent) == CMIEntityType.SPLASH_POTION) {
 
@@ -407,14 +404,9 @@ public class ResidenceEntityListener implements Listener {
         if (cause == null)
             return;
 
-        if (ResAdmin.isResAdmin(cause))
-            return;
-
-        if (FlagPermissions.has(entity.getLocation(), cause, Flags.animalkilling, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(cause, Flags.animalkilling);
-        event.setCancelled(true);
+        if (FlagPermissions.shouldDenyAndNotify(cause, entity, Flags.animalkilling, null)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -482,8 +474,7 @@ public class ResidenceEntityListener implements Listener {
             return;
 
         FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation());
-        FlagPermissions world = plugin.getWorldFlags().getPerms(entity.getWorld().getName());
-        if (!perms.has(Flags.animalkilling, world.has(Flags.animalkilling, true))) {
+        if (!perms.has(Flags.animalkilling, true)) {
             event.setCancelled(true);
         }
     }
@@ -537,10 +528,10 @@ public class ResidenceEntityListener implements Listener {
         if (FlagPermissions.shouldIgnoreCheck(Flags.vehicledestroy, damager)) {
             return;
         }
-        if (!(event.getEntity() instanceof Vehicle))
+        if (event.getEntity() instanceof LivingEntity) {
             return;
-
-        if (Utils.isAnimal(event.getEntity()))
+        }
+        if (!(event.getEntity() instanceof Vehicle))
             return;
 
         Vehicle vehicle = (Vehicle) event.getEntity();
@@ -610,64 +601,27 @@ public class ResidenceEntityListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-    public void onFenceLeashInteract(PlayerInteractEntityEvent event) {
-
-        Entity entity = event.getRightClicked();
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.leash, entity)) {
-            return;
-        }
-        if (CMIEntityType.get(entity.getType()) != CMIEntityType.LEASH_KNOT)
-            return;
-
-        Player player = event.getPlayer();
-
-        if (FlagPermissions.shouldDenyAndNotify(player, entity, Flags.leash, null)) {
-            event.setCancelled(true);
-        }
-    }
-
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onWitherSpawn(CreatureSpawnEvent event) {
+    public void onPhantomOrWitherSpawn(CreatureSpawnEvent event) {
 
-        Entity ent = event.getEntity();
-        if (ent == null)
-            return;
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.witherspawn, ent)) {
+        Entity entity = event.getEntity();
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(entity)) {
             return;
         }
+        Flags flag;
+        if (Flags.witherspawn.isGlobalyEnabled() && entity instanceof Wither) {
+            flag = Flags.witherspawn;
 
-        if (ent.getType() != EntityType.WITHER)
+        } else if (Flags.phantomspawn.isGlobalyEnabled() && Utils.isPhantom(entity)) {
+            flag = Flags.phantomspawn;
+
+        } else {
             return;
-
+        }
         FlagPermissions perms = FlagPermissions.getPerms(event.getLocation());
-        if (perms.has(Flags.witherspawn, FlagCombo.OnlyFalse)) {
+        if (perms.has(flag, FlagCombo.OnlyFalse)) {
             event.setCancelled(true);
-            return;
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onPhantomSpawn(CreatureSpawnEvent event) {
-        if (Version.isCurrentLower(Version.v1_13_R1))
-            return;
-
-        Entity ent = event.getEntity();
-        if (ent == null)
-            return;
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.phantomspawn, ent)) {
-            return;
-        }
-        if (ent.getType() != EntityType.PHANTOM)
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(event.getLocation());
-        if (perms.has(Flags.phantomspawn, FlagCombo.OnlyFalse)) {
-            event.setCancelled(true);
-            return;
         }
     }
 
@@ -828,29 +782,6 @@ public class ResidenceEntityListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onHangingBreak(HangingBreakByEntityEvent event) {
-
-        Hanging ent = event.getEntity();
-        if (ent == null)
-            return;
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.destroy, ent)) {
-            return;
-        }
-        if (!(event.getRemover() instanceof Player))
-            return;
-
-        Player player = (Player) event.getRemover();
-
-        if (plugin.getResidenceManager().isOwnerOfLocation(player, ent.getLocation()))
-            return;
-
-        if (FlagPermissions.shouldDenyAndNotify(player, ent, Flags.destroy, Flags.build)) {
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onHangingBreakEventByExplosion(HangingBreakEvent event) {
 
         Hanging ent = event.getEntity();
@@ -864,7 +795,7 @@ public class ResidenceEntityListener implements Listener {
             return;
 
         FlagPermissions perms = FlagPermissions.getPerms(ent.getLocation());
-        if (perms.has(Flags.explode, FlagCombo.OnlyFalse)) {
+        if (!perms.has(Flags.explode, perms.has(Flags.destroy, true))) {
             event.setCancelled(true);
         }
     }
@@ -902,16 +833,23 @@ public class ResidenceEntityListener implements Listener {
         if (FlagPermissions.shouldIgnoreCheck(Flags.destroy, ent)) {
             return;
         }
-        if (event.getRemover() instanceof Player)
-            return;
+        if (event.getRemover() instanceof Player) {
+            Player player = (Player) event.getRemover();
 
-        FlagPermissions perms = FlagPermissions.getPerms(ent.getLocation());
-        if (!perms.has(Flags.destroy, perms.has(Flags.build, true))) {
-
-            if (Utils.isSourceBlockInsideSameResidence(event.getRemover(), ClaimedResidence.getByLoc(event.getEntity().getLocation())))
+            if (plugin.getResidenceManager().isOwnerOfLocation(player, ent.getLocation())) {
                 return;
-
-            event.setCancelled(true);
+            }
+            if (FlagPermissions.shouldDenyAndNotify(player, ent, Flags.destroy, Flags.build)) {
+                event.setCancelled(true);
+            }
+        } else {
+            if (Utils.isSourceBlockInsideSameResidence(event.getRemover(), ClaimedResidence.getByLoc(event.getEntity().getLocation()))) {
+                return;
+            }
+            FlagPermissions perms = FlagPermissions.getPerms(ent.getLocation());
+            if (!perms.has(Flags.destroy, perms.has(Flags.build, true))) {
+                event.setCancelled(true);
+            }
         }
     }
 
@@ -1355,231 +1293,14 @@ public class ResidenceEntityListener implements Listener {
             event.setCancelled(true);
     }
 
-    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void OnFallDamage(EntityDamageEvent event) {
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.falldamage, event.getEntity())) {
-            return;
-        }
-        if (event.getCause() != DamageCause.FALL)
-            return;
-        Entity ent = event.getEntity();
-        if (!(ent instanceof Player))
-            return;
-
-        if (!FlagPermissions.getPerms(ent.getLocation()).has(Flags.falldamage, FlagCombo.TrueOrNone)) {
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void OnArmorStandFlameDamage(EntityDamageEvent event) {
-
-        Entity ent = event.getEntity();
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.destroy, ent)) {
-            return;
-        }
-        if (event.getCause() != DamageCause.FIRE_TICK)
-            return;
-
-        if (!Utils.isArmorStandEntity(ent.getType()) && !(ent instanceof Arrow))
-            return;
-
-        if (!FlagPermissions.getPerms(ent.getLocation()).has(Flags.destroy, true)) {
-            event.setCancelled(true);
-            ent.setFireTicks(0);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void OnArmorStandExplosion(EntityDamageEvent event) {
-
-        Entity ent = event.getEntity();
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.destroy, ent)) {
-            return;
-        }
-        if (event.getCause() != DamageCause.BLOCK_EXPLOSION && event.getCause() != DamageCause.ENTITY_EXPLOSION)
-            return;
-
-        if (!Utils.isArmorStandEntity(ent.getType()) && !(ent instanceof Arrow))
-            return;
-
-        if (!FlagPermissions.getPerms(ent.getLocation()).has(Flags.destroy, true)) {
-            event.setCancelled(true);
-            ent.setFireTicks(0);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onEntityCatchingFire(EntityDamageByEntityEvent event) {
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.pvp, event.getEntity())) {
-            return;
-        }
-        if (!damageableProjectile(event.getDamager()))
-            return;
-
-        if (!(event.getEntity() instanceof Player))
-            return;
-
-        Projectile projectile = (Projectile) event.getDamager();
-
-        FlagPermissions perms = FlagPermissions.getPerms(projectile.getLocation());
-
-        if (!perms.has(Flags.pvp, FlagCombo.TrueOrNone))
-            projectile.setFireTicks(0);
-    }
-
-    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void OnPlayerDamageByLightning(EntityDamageEvent event) {
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.pvp, event.getEntity())) {
-            return;
-        }
-        if (event.getCause() != DamageCause.LIGHTNING)
-            return;
-        Entity ent = event.getEntity();
-        if (!(ent instanceof Player))
-            return;
-        if (!FlagPermissions.getPerms(ent.getLocation()).has(Flags.pvp, FlagCombo.TrueOrNone))
-            event.setCancelled(true);
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onEntityDamageByFireballEvent(EntityDamageByEntityEvent event) {
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.fireball, event.getEntity())) {
-            return;
-        }
-        Entity dmgr = event.getDamager();
-        if (dmgr.getType() != EntityType.SMALL_FIREBALL && dmgr.getType() != EntityType.FIREBALL)
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(event.getEntity().getLocation());
-        if (perms.has(Flags.fireball, FlagCombo.OnlyFalse)) {
-            event.setCancelled(true);
-            return;
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onEntityDamageByWitherEvent(EntityDamageByEntityEvent event) {
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.witherdamage, event.getEntity())) {
-            return;
-        }
-        Entity dmgr = event.getDamager();
-        if (dmgr.getType() != EntityType.WITHER && dmgr.getType() != EntityType.WITHER_SKULL)
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(event.getEntity().getLocation());
-        if (perms.has(Flags.witherdamage, FlagCombo.OnlyFalse)) {
-            event.setCancelled(true);
-            return;
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onEntityDamageByEntityEvent(EntityDamageByEntityEvent event) {
-        Entity entity = event.getEntity();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity))
-            return;
-
-        if (!(entity instanceof EnderCrystal) && !(entity instanceof ItemFrame)
-                && CMIEntityType.get(entity) != CMIEntityType.ARMOR_STAND) {
-            return;
-        }
-
-        Entity dmgr = event.getDamager();
-
-        Player player = Utils.potentialProjectileToPlayer(dmgr);
-
-        CMIEntityType damageBy = CMIEntityType.get(dmgr.getType());
-
-        if (dmgr instanceof Projectile && player == null) {
-
-            if (Utils.isSourceBlockInsideSameResidence(dmgr, ClaimedResidence.getByLoc(entity.getLocation())))
-                return;
-
-            FlagPermissions perm = FlagPermissions.getPerms(entity.getLocation());
-            if (perm.has(Flags.destroy, FlagCombo.OnlyFalse)) {
-                event.setCancelled(true);
-            }
-            return;
-
-        } else if (damageBy == CMIEntityType.TNT || damageBy == CMIEntityType.TNT_MINECART) {
-
-            // Disabling listener if flag disabled globally
-            if (Flags.explode.isGlobalyEnabled()) {
-                FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation());
-                if (!perms.has(Flags.explode, perms.has(Flags.destroy, true))) {
-                    event.setCancelled(true);
-                    return;
-                }
-            }
-            return;
-
-        } else if (damageBy == CMIEntityType.WITHER_SKULL || damageBy == CMIEntityType.WITHER) {
-
-            // Disabling listener if flag disabled globally
-            if (Flags.witherdestruction.isGlobalyEnabled()) {
-                FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation());
-                if (!perms.has(Flags.witherdestruction, perms.has(Flags.destroy, true))) {
-                    event.setCancelled(true);
-                    return;
-                }
-            }
-            return;
-        }
-
-        FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation(), player);
-
-        if (isMonster(dmgr) && !perms.has(Flags.destroy, false)) {
-            event.setCancelled(true);
-            return;
-        }
-
-        if (player == null)
-            return;
-
-        if (ResAdmin.isResAdmin(player))
-            return;
-
-        // ItemFrame covers item_frame/glow_item_frame
-        if (entity instanceof ItemFrame) {
-            ItemStack stack = ((ItemFrame) entity).getItem();
-
-            if (stack != null) {
-                if (!ResPerm.bypass_container.hasPermission(player, 10000L) && !perms.playerHas(player, Flags.container, true)) {
-                    event.setCancelled(true);
-                    lm.Flag_Deny.sendMessage(player, Flags.container);
-                }
-
-                // Specific fix for the Itemadders plugin.
-                // Custom event will not have damage source while it contains item as paper
-                // inside of it
-                if (Version.isCurrentEqualOrHigher(Version.v1_21_R1) && event.getDamageSource() != null && event.getDamageSource().getCausingEntity() == null && !perms.playerHas(player, Flags.destroy,
-                        perms.playerHas(player, Flags.build, true))) {
-                    event.setCancelled(true);
-                    lm.Flag_Deny.sendMessage(player, Flags.destroy);
-                }
-
-                return;
-            }
-        }
-
-        if (!perms.playerHas(player, Flags.destroy, perms.playerHas(player, Flags.build, true))) {
-            event.setCancelled(true);
-            lm.Flag_Deny.sendMessage(player, Flags.destroy);
-        }
-    }
-
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityShootBowEvent(EntityShootBowEvent event) {
-
+        // issues https://github.com/Zrips/Residence/issues/466
+        // Not sure when Paper stopped needing this, so to be safe, we'll only skip it for Paper 1.21+
+        // https://github.com/PaperMC/Paper/pull/10307
+        if (Version.isCurrentEqualOrHigher(Version.v1_21_0) && Version.isPaperBranch()) {
+            return;
+        }
         if (Version.isCurrentEqualOrLower(Version.v1_14_R1))
             return;
 
@@ -1592,264 +1313,232 @@ public class ResidenceEntityListener implements Listener {
         if (!(event.getEntity() instanceof Player))
             return;
 
-        if (CMIEntityType.get(event.getProjectile()) == CMIEntityType.FIREWORK_ROCKET)
+        if (event.getProjectile() instanceof Firework) {
             event.getProjectile().setMetadata(CrossbowShooter, new FixedMetadataValue(plugin, event.getEntity().getUniqueId()));
+        }
     }
 
-    public static boolean canDamageEntity(Entity damager, Entity victim, boolean inform) {
-
-        boolean tamedAnimal = isTamed(victim);
-        ClaimedResidence area = Residence.getInstance().getResidenceManager().getByLoc(victim.getLocation());
-
-        ClaimedResidence srcarea = null;
-        if (damager != null) {
-            srcarea = Residence.getInstance().getResidenceManager().getByLoc(damager.getLocation());
-        }
-        boolean srcpvp = true;
-        boolean allowSnowBall = false;
-        boolean isSnowBall = false;
-        boolean isOnFire = false;
-        if (srcarea != null) {
-            srcpvp = srcarea.getPermissions().has(Flags.pvp, FlagCombo.TrueOrNone);
-        }
-
-//	    ent = attackevent.getEntity();
-        if ((victim instanceof Player || tamedAnimal) && (damager instanceof Player || (damager instanceof Projectile && (((Projectile) damager)
-                .getShooter() instanceof Player))) || damager instanceof Firework) {
-
-            Player attacker = null;
-            if (damager instanceof Player) {
-                attacker = (Player) damager;
-            } else if (damager instanceof Projectile) {
-                Projectile project = (Projectile) damager;
-                if (project.getType() == EntityType.SNOWBALL && srcarea != null) {
-                    isSnowBall = true;
-                    allowSnowBall = srcarea.getPermissions().has(Flags.snowball, FlagCombo.TrueOrNone);
-                }
-                if (project.getFireTicks() > 0)
-                    isOnFire = true;
-
-                attacker = (Player) ((Projectile) damager).getShooter();
-            } else if (damager instanceof Firework) {
-                List<MetadataValue> meta = damager.getMetadata(CrossbowShooter);
-                if (meta != null && !meta.isEmpty()) {
-                    try {
-                        String uid = meta.get(0).asString();
-                        attacker = Bukkit.getPlayer(UUID.fromString(uid));
-                    } catch (Throwable e) {
-                    }
-                }
-            }
-
-            if (!(victim instanceof Player))
-                return true;
-
-            if (srcarea != null && area != null && srcarea.equals(area) && attacker != null && area.getRaid().isUnderRaid() && area.getRaid().onSameTeam(attacker, (Player) victim)
-                    && !ConfigManager.RaidFriendlyFire) {
-                return false;
-            }
-
-            if (srcarea != null && area != null && srcarea.equals(area) && attacker != null && area.getRaid().isUnderRaid() && !area.getRaid().onSameTeam(attacker, (Player) victim)) {
-                return true;
-            }
-
-            if (srcarea != null && area != null && srcarea.equals(area) && attacker != null &&
-                    srcarea.getPermissions().playerHas((Player) victim, Flags.friendlyfire, FlagCombo.OnlyFalse) &&
-                    srcarea.getPermissions().playerHas(attacker, Flags.friendlyfire, FlagCombo.OnlyFalse)) {
-
-                CMIActionBar.send(attacker, Residence.getInstance().getLM().getMessage(lm.General_NoFriendlyFire));
-                if (isOnFire)
-                    victim.setFireTicks(0);
-                return false;
-            }
-
-            if (!srcpvp && !isSnowBall || !allowSnowBall && isSnowBall) {
-                if (attacker != null && inform)
-                    lm.General_NoPVPZone.sendMessage(attacker);
-                if (isOnFire)
-                    victim.setFireTicks(0);
-                return false;
-            }
-
-            /* Check for Player vs Player */
-            if (area == null) {
-                /* World PvP */
-                if (damager != null)
-                    if (!Residence.getInstance().getWorldFlags().getPerms(damager.getWorld().getName()).has(Flags.pvp, FlagCombo.TrueOrNone)) {
-                        if (attacker != null && inform)
-                            lm.General_WorldPVPDisabled.sendMessage(attacker);
-                        return false;
-                    }
-
-                /* Attacking from safe zone */
-                if (attacker != null) {
-                    FlagPermissions aPerm = FlagPermissions.getPerms(attacker.getLocation());
-                    if (!aPerm.has(Flags.pvp, FlagCombo.TrueOrNone)) {
-                        if (inform)
-                            lm.General_NoPVPZone.sendMessage(attacker);
-                        return false;
-                    }
-                }
-            } else {
-                /* Normal PvP */
-                if (!isSnowBall && !area.getPermissions().has(Flags.pvp, FlagCombo.TrueOrNone) || isSnowBall && !allowSnowBall) {
-                    if (attacker != null)
-                        if (inform)
-                            lm.General_NoPVPZone.sendMessage(attacker);
-                    return false;
-                }
-            }
-            return true;
-        } else if ((victim instanceof Player || tamedAnimal) && (damager instanceof Creeper)) {
-            if (area == null && !Residence.getInstance().getWorldFlags().getPerms(damager.getWorld().getName()).has(Flags.creeper, true) || area != null && !area.getPermissions().has(Flags.creeper,
-                    true)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private static void process(lm lm, Player attacker, boolean isOnFire, Entity ent, EntityDamageEvent event, Entity damager) {
+    private static void process(lm lm, Player attacker, boolean isOnFire, Entity victim, EntityDamageEvent event) {
         if (attacker != null)
             lm.sendMessage(attacker);
         if (isOnFire)
-            ent.setFireTicks(0);
+            victim.setFireTicks(0);
         event.setCancelled(true);
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onEntityDamage(EntityDamageEvent event) {
+    public void onPlayerDamageByPlayer(EntityDamageByEntityEvent event) {
+        Entity victim = event.getEntity();
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity()))
+        if (plugin.isDisabledWorldListener(victim)) {
             return;
-        Entity ent = event.getEntity();
-        if (ent.hasMetadata("NPC"))
+        }
+        if (!(victim instanceof Player) || victim.hasMetadata("NPC")) {
             return;
+        }
+        Entity attacker = event.getDamager();
+        Player attackerPlayer = null;
+        boolean isOnFire = false;
 
-        boolean tamedAnimal = isTamed(ent);
-        ClaimedResidence area = plugin.getResidenceManager().getByLoc(ent.getLocation());
-        /* Living Entities */
-        if (event instanceof EntityDamageByEntityEvent) {
-            EntityDamageByEntityEvent attackevent = (EntityDamageByEntityEvent) event;
-            Entity damager = attackevent.getDamager();
+        if (attacker instanceof Player) {
+            attackerPlayer = (Player) attacker;
 
-            ClaimedResidence srcarea = null;
-            if (damager != null) {
-                srcarea = plugin.getResidenceManager().getByLoc(damager.getLocation());
+            // issues https://github.com/Zrips/Residence/issues/466
+            // Not sure when Paper stopped needing this, so to be safe, we'll only skip it for Paper 1.21+
+            // https://github.com/PaperMC/Paper/pull/10307
+            // In higher versions, Firework also belongs to Projectile, and the shooter can be obtained normall
+        } else if (attacker instanceof Firework && (!Version.isPaperBranch() || Version.isCurrentLower(Version.v1_21_0))) {
+            List<MetadataValue> meta = attacker.getMetadata(CrossbowShooter);
+            if (meta != null && !meta.isEmpty()) {
+                try {
+                    String uid = meta.get(0).asString();
+                    attackerPlayer = Bukkit.getPlayer(UUID.fromString(uid));
+                } catch (Throwable e) {
+                }
             }
-            boolean srcpvp = true;
-            boolean allowSnowBall = false;
-            boolean isSnowBall = false;
-            boolean isOnFire = false;
-            if (srcarea != null) {
-                srcpvp = srcarea.getPermissions().has(Flags.pvp, FlagCombo.TrueOrNone);
-            }
 
-            ent = attackevent.getEntity();
-            if ((ent instanceof Player || tamedAnimal) && (damager instanceof Player || (damager instanceof Projectile && (((Projectile) damager)
-                    .getShooter() instanceof Player))) && event.getCause() != DamageCause.FALL || damager instanceof Firework) {
-
-                Player attacker = null;
-                if (damager instanceof Player) {
-                    attacker = (Player) damager;
-                } else if (damager instanceof Projectile) {
-                    Projectile project = (Projectile) damager;
-                    if (project.getType() == EntityType.SNOWBALL && srcarea != null) {
-                        isSnowBall = true;
-                        allowSnowBall = srcarea.getPermissions().has(Flags.snowball, FlagCombo.TrueOrNone);
-                    }
-                    if (project.getFireTicks() > 0)
-                        isOnFire = true;
-
-                    ProjectileSource shooter = ((Projectile) damager).getShooter();
-                    if (shooter instanceof Player)
-                        attacker = (Player) shooter;
-                } else if (damager instanceof Firework) {
-                    List<MetadataValue> meta = damager.getMetadata(CrossbowShooter);
-                    if (meta != null && !meta.isEmpty()) {
-                        try {
-                            String uid = meta.get(0).asString();
-                            attacker = Bukkit.getPlayer(UUID.fromString(uid));
-                        } catch (Throwable e) {
-                        }
-                    }
-                }
-
-                if (!(ent instanceof Player))
-                    return;
-
-                if (srcarea != null && area != null && srcarea.equals(area) && attacker != null && area.getRaid().isUnderRaid() && area.getRaid().onSameTeam(attacker, (Player) ent)
-                        && !ConfigManager.RaidFriendlyFire) {
-                    event.setCancelled(true);
-                }
-
-                if (srcarea != null && area != null && srcarea.equals(area) && attacker != null && area.getRaid().isUnderRaid() && !area.getRaid().onSameTeam(attacker, (Player) ent)) {
-                    return;
-                }
-
-                if (srcarea != null && area != null && srcarea.equals(area) && attacker != null &&
-                        srcarea.getPermissions().playerHas((Player) ent, Flags.friendlyfire, FlagCombo.OnlyFalse) &&
-                        srcarea.getPermissions().playerHas(attacker, Flags.friendlyfire, FlagCombo.OnlyFalse)) {
-
-                    CMIActionBar.send(attacker, plugin.getLM().getMessage(lm.General_NoFriendlyFire));
-                    if (isOnFire)
-                        ent.setFireTicks(0);
-                    event.setCancelled(true);
-                }
-
-                if (!srcpvp && !isSnowBall || !allowSnowBall && isSnowBall) {
-                    process(lm.General_NoPVPZone, attacker, isOnFire, ent, event, damager);
-                    return;
-                }
-
-                /* Check for Player vs Player */
-                if (area == null) {
-                    /* World PvP */
-                    if (damager != null)
-                        if (!plugin.getWorldFlags().getPerms(damager.getWorld().getName()).has(Flags.pvp, FlagCombo.TrueOrNone)) {
-                            process(lm.General_WorldPVPDisabled, attacker, isOnFire, ent, event, damager);
-                            return;
-                        }
-
-                    /* Attacking from safe zone */
-                    if (attacker != null) {
-                        FlagPermissions aPerm = FlagPermissions.getPerms(attacker.getLocation());
-                        if (!aPerm.has(Flags.pvp, FlagCombo.TrueOrNone)) {
-                            process(lm.General_NoPVPZone, attacker, isOnFire, ent, event, damager);
-                            return;
-                        }
-                    }
-                } else {
-                    /* Normal PvP */
-                    if (!isSnowBall && !area.getPermissions().has(Flags.pvp, FlagCombo.TrueOrNone) || isSnowBall && !allowSnowBall) {
-                        process(lm.General_NoPVPZone, attacker, isOnFire, ent, event, damager);
-                        return;
-                    }
-                }
+        } else if (attacker instanceof Projectile) {
+            Projectile project = (Projectile) attacker;
+            ProjectileSource shooter = project.getShooter();
+            if (!(shooter instanceof Player)) {
                 return;
-            } else if ((ent instanceof Player || tamedAnimal) && (damager instanceof Creeper)) {
-                if (area == null && !plugin.getWorldFlags().getPerms(damager.getWorld().getName()).has(Flags.creeper, true)) {
+            }
+            attackerPlayer = (Player) shooter;
+            if (project.getFireTicks() > 0) {
+                isOnFire = true;
+            }
+
+        }
+        if (attackerPlayer == null || attackerPlayer.hasMetadata("NPC")) {
+            return;
+        }
+        // Now both the attacker and the victim are guaranteed to be players
+        ClaimedResidence attackerRes = ClaimedResidence.getByLoc(attacker.getLocation());
+        ClaimedResidence victimRes = ClaimedResidence.getByLoc(victim.getLocation());
+        // Attacker and victim are in the same Residence
+        if (attackerRes != null && victimRes != null && attackerRes.equals(victimRes)) {
+
+            if (ConfigManager.RaidEnabled && victimRes.getRaid().isUnderRaid()) {
+                boolean raidSameTeam = victimRes.getRaid().onSameTeam(attackerPlayer, (Player) victim);
+                if (raidSameTeam && !ConfigManager.RaidFriendlyFire) {
                     event.setCancelled(true);
-                } else if (area != null && !area.getPermissions().has(Flags.creeper, true)) {
-                    event.setCancelled(true);
+                    return;
+                }
+                if (!raidSameTeam) {
+                    return;
+                }
+            }
+            if (attackerRes.getPermissions().has(Flags.pvp, FlagCombo.OnlyFalse)) {
+                process(lm.General_NoPVPZone, attackerPlayer, isOnFire, victim, event);
+                return;
+            }
+            if (attackerRes.getPermissions().playerHas((Player) victim, Flags.friendlyfire, FlagCombo.OnlyFalse)
+                    && attackerRes.getPermissions().playerHas(attackerPlayer, Flags.friendlyfire, FlagCombo.OnlyFalse)) {
+                CMIActionBar.send(attackerPlayer, plugin.getLM().getMessage(lm.General_NoFriendlyFire));
+                event.setCancelled(true);
+                if (isOnFire) {
+                    victim.setFireTicks(0);
+                }
+            }
+            // Attacker and victim are not in the same Residence
+        } else {
+            // if PVP disabled at attacker location, cancel event
+            if (attackerRes != null && attackerRes.getPermissions().has(Flags.pvp, FlagCombo.OnlyFalse)) {
+                process(lm.General_NoPVPZone, attackerPlayer, isOnFire, victim, event);
+                return;
+            }
+            // if PVP disabled at victim location, cancel event
+            if (victimRes != null && victimRes.getPermissions().has(Flags.pvp, FlagCombo.OnlyFalse)) {
+                process(lm.General_NoPVPZone, attackerPlayer, isOnFire, victim, event);
+                return;
+            }
+            // Now attacker and victim are not in Residence
+            if (attackerRes == null && victimRes == null) {
+                /* World PvP */
+                if (plugin.getWorldFlags().getPerms(attackerPlayer.getWorld()).has(Flags.pvp, FlagCombo.OnlyFalse)) {
+                    process(lm.General_WorldPVPDisabled, attackerPlayer, isOnFire, victim, event);
+                    return;
                 }
             }
         }
-        if (area == null) {
-            if (!plugin.getWorldFlags().getPerms(ent.getWorld().getName()).has(Flags.damage, true) && (ent instanceof Player || tamedAnimal)) {
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
+        Entity victim = event.getEntity();
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(victim)) {
+            return;
+        }
+        // Decorative entity damage uses separate logic
+        if (victim instanceof EnderCrystal || victim instanceof ItemFrame || Utils.isArmorStand(victim)) {
+            handleDecorativeEntityDamage(event);
+            return;
+        }
+        Entity attacker = event.getDamager();
+        Flags mainFlag = null;
+        Flags subFlag = null;
+
+        if (Flags.creeper.isGlobalyEnabled() && attacker instanceof Creeper) {
+            mainFlag = Flags.creeper;
+            subFlag = Flags.explode;
+
+        } else if (Flags.explode.isGlobalyEnabled() && attacker instanceof EnderCrystal) {
+            mainFlag = Flags.explode;
+            subFlag = Flags.destroy;
+
+        } else if (Flags.fireball.isGlobalyEnabled() && (event.getEntityType() == EntityType.FIREBALL || event.getEntityType() == EntityType.SMALL_FIREBALL)) {
+            mainFlag = Flags.fireball;
+
+        } else if (Flags.snowball.isGlobalyEnabled() && attacker instanceof Snowball) {
+            mainFlag = Flags.snowball;
+
+        } else if (Flags.tnt.isGlobalyEnabled() && (attacker instanceof TNTPrimed || attacker instanceof ExplosiveMinecart)) {
+            mainFlag = Flags.tnt;
+            subFlag = Flags.explode;
+
+        } else if (Flags.witherdestruction.isGlobalyEnabled() && (attacker instanceof Wither || attacker instanceof WitherSkull)) {
+            mainFlag = Flags.witherdamage;
+
+        }
+        if (mainFlag != null) {
+            FlagPermissions perms = FlagPermissions.getPerms(victim.getLocation());
+            boolean result = (subFlag == null || perms.has(subFlag, true));
+            if (perms.has(mainFlag, result)) {
+                return;
+            }
+            event.setCancelled(true);
+        }
+    }
+
+    private void handleDecorativeEntityDamage(EntityDamageByEntityEvent event) {
+        Entity attacker = event.getDamager();
+        Entity victim = event.getEntity();
+        Player player = Utils.potentialProjectileToPlayer(attacker);
+        // if player damages ItemFrame with items inside, check Flags.container
+        // this corresponds to taking the item out of the ItemFrame
+        if (Flags.container.isGlobalyEnabled() && player != null && victim instanceof ItemFrame
+                && ((ItemFrame) victim).getItem() != null && ((ItemFrame) victim).getItem().getType() != Material.AIR) {
+            if (ResPerm.bypass_container.hasPermission(player, 10000L)) {
+                return;
+            }
+            if (FlagPermissions.shouldDenyAndNotify(player, victim, Flags.container, Flags.use)) {
                 event.setCancelled(true);
             }
-        } else {
-            if (!area.getPermissions().has(Flags.damage, true) && (ent instanceof Player || tamedAnimal)) {
+            // damage from player or player-fired projectile
+        } else if (Flags.destroy.isGlobalyEnabled() && player != null) {
+            if (FlagPermissions.shouldDenyAndNotify(player, victim, Flags.destroy, Flags.build)) {
+                event.setCancelled(true);
+            }
+            // damage from non-players or projectiles fired by non-players
+        } else if (Flags.destroy.isGlobalyEnabled()) {
+            if (attacker instanceof Projectile && Utils.isSourceBlockInsideSameResidence(attacker, ClaimedResidence.getByLoc(victim.getLocation()))) {
+                return;
+            }
+            FlagPermissions perms = FlagPermissions.getPerms(victim.getLocation());
+            if (!perms.has(Flags.destroy, perms.has(Flags.build, true))) {
                 event.setCancelled(true);
             }
         }
-        if (event.isCancelled()) {
-            /* Put out a fire on a player */
-            if ((ent instanceof Player || tamedAnimal) && (event.getCause() == EntityDamageEvent.DamageCause.FIRE || event
-                    .getCause() == EntityDamageEvent.DamageCause.FIRE_TICK)) {
-                ent.setFireTicks(0);
-            }
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onEntityDamageEvent(EntityDamageEvent event) {
+
+        Entity entity = event.getEntity();
+
+        if (plugin.isDisabledWorldListener(entity)) {
+            return;
         }
+        if (Flags.damage.isGlobalyEnabled() && event.getCause() != DamageCause.VOID
+                && (entity instanceof Player || Utils.isTamed(entity))
+                && FlagPermissions.has(entity.getLocation(), Flags.damage, FlagCombo.OnlyFalse)) {
+            event.setCancelled(true);
+            entity.setFireTicks(0);
+            return;
+        }
+
+        if (Flags.falldamage.isGlobalyEnabled() && event.getCause() == DamageCause.FALL && entity instanceof Player) {
+            if (FlagPermissions.has(entity.getLocation(), Flags.falldamage, FlagCombo.OnlyFalse)) {
+                event.setCancelled(true);
+            }
+            return;
+        }
+        if (Flags.pvp.isGlobalyEnabled() && event.getCause() == DamageCause.LIGHTNING && entity instanceof Player) {
+            if (FlagPermissions.has(entity.getLocation(), Flags.pvp, FlagCombo.OnlyFalse)) {
+                event.setCancelled(true);
+            }
+            return;
+        }
+        if (Flags.destroy.isGlobalyEnabled()
+                && (event.getCause() == DamageCause.BLOCK_EXPLOSION || event.getCause() == DamageCause.ENTITY_EXPLOSION || event.getCause() == DamageCause.FIRE_TICK)
+                && (entity instanceof Arrow || Utils.isArmorStand(entity))) {
+            if (FlagPermissions.has(entity.getLocation(), Flags.destroy, FlagCombo.OnlyFalse)) {
+                event.setCancelled(true);
+                entity.setFireTicks(0);
+            }
+            return;
+        }
+
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
@@ -133,7 +133,7 @@ public class ResidenceEntityListener implements Listener {
             shouldDeny = shouldDenyPlayerChangeBlock(block, (Player) entity);
 
         } else if (Flags.destroy.isGlobalyEnabled() && entity instanceof Boat) {
-            shouldDeny = shouldDenyBoatBreakLilyPad(entity, block);
+            shouldDeny = shouldDenyBoatBreakLilyPad((Boat) entity, block);
 
         } else if (Flags.destroy.isGlobalyEnabled() && entity instanceof Projectile) {
             // Projectile-triggered EntityChangeBlockEvent always breaks blocks
@@ -169,15 +169,15 @@ public class ResidenceEntityListener implements Listener {
         return false;
     }
 
-    private boolean shouldDenyBoatBreakLilyPad(Entity entity, Block block) {
+    private boolean shouldDenyBoatBreakLilyPad(Boat boat, Block block) {
         if (CMIMaterial.get(block.getType()) != CMIMaterial.LILY_PAD) {
             return false;
         }
         Entity rider = null;
         if (Version.isCurrentLower(Version.v1_11_2)) {
-            rider = entity.getPassenger();
+            rider = boat.getPassenger();
         } else {
-            List<Entity> passengers = entity.getPassengers();
+            List<Entity> passengers = boat.getPassengers();
             if (!passengers.isEmpty()) {
                 // first passenger
                 rider = passengers.get(0);
@@ -331,7 +331,7 @@ public class ResidenceEntityListener implements Listener {
         if (entity == null) {
             return false;
         }
-        if (Version.isCurrentEqualOrHigher(Version.v1_19_3)) {
+        if (Version.isCurrentEqualOrHigher(Version.v1_19_R2)) {
             return entity instanceof org.bukkit.entity.Enemy;
         }
         if (entity instanceof Monster) {
@@ -355,11 +355,11 @@ public class ResidenceEntityListener implements Listener {
     }
 
     private static boolean isTamed(Entity ent) {
-        return (ent instanceof Tameable ? ((Tameable) ent).isTamed() : false);
+        return ent instanceof Tameable && ((Tameable) ent).isTamed();
     }
 
     private static boolean damageableProjectile(Entity ent) {
-        if (ent instanceof Projectile && ent.getType().toString().equalsIgnoreCase("Splash_potion")) {
+        if (ent instanceof Projectile && CMIEntityType.get(ent) == CMIEntityType.SPLASH_POTION) {
 
             if (((ThrownPotion) ent).getEffects().isEmpty())
                 return true;
@@ -370,7 +370,7 @@ public class ResidenceEntityListener implements Listener {
                 }
             }
         }
-        return ent instanceof Projectile || ent.getType().toString().equalsIgnoreCase("Trident") || ent.getType().toString().equalsIgnoreCase("Spectral_Arrow");
+        return ent instanceof Projectile;
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -851,8 +851,9 @@ public class ResidenceEntityListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onProjectileLaunch(ProjectileLaunchEvent event) {
+        Projectile projectile = event.getEntity();
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld())) {
+        if (plugin.isDisabledWorldListener(projectile.getWorld())) {
             return;
         }
         Flags flag = Flags.shoot;
@@ -876,22 +877,24 @@ public class ResidenceEntityListener implements Listener {
         if (!flag.isGlobalyEnabled()) {
             return;
         }
-        ProjectileSource shooter = event.getEntity().getShooter();
+        ProjectileSource shooter = projectile.getShooter();
+        if (shooter instanceof Player) {
 
-        Player player = null;
-        boolean isPlayer = shooter instanceof Player;
-        if (isPlayer) {
-            player = (Player) shooter;
-            if (ResAdmin.isResAdmin(player)) {
+            Player player = (Player) shooter;
+            if (player.hasMetadata("NPC") || ResAdmin.isResAdmin(player)) {
                 return;
             }
-        }
-        FlagPermissions perms = FlagPermissions.getPerms(event.getEntity().getLocation());
-        if (perms.has(flag, FlagCombo.OnlyFalse)) {
-            if (isPlayer) {
+            FlagPermissions perms = FlagPermissions.getPerms(projectile.getLocation(), player);
+            if (perms.playerHas(player, flag, FlagCombo.OnlyFalse)) {
                 lm.Flag_Deny.sendMessage(player, flag);
+                event.setCancelled(true);
             }
-            event.setCancelled(true);
+
+        } else {
+            FlagPermissions perms = FlagPermissions.getPerms(projectile.getLocation());
+            if (perms.has(flag, FlagCombo.OnlyFalse)) {
+                event.setCancelled(true);
+            }
         }
     }
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceEntityListener.java
@@ -57,6 +57,7 @@ import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.hanging.HangingBreakEvent.RemoveCause;
 import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.event.vehicle.VehicleDestroyEvent;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.potion.PotionEffect;
@@ -75,6 +76,7 @@ import com.bekvon.bukkit.residence.utils.Utils;
 
 import net.Zrips.CMILib.ActionBar.CMIActionBar;
 import net.Zrips.CMILib.Entities.CMIEntityType;
+import net.Zrips.CMILib.Items.CMIItemStack;
 import net.Zrips.CMILib.Items.CMIMC;
 import net.Zrips.CMILib.Items.CMIMaterial;
 import net.Zrips.CMILib.Version.Version;
@@ -1430,12 +1432,22 @@ public class ResidenceEntityListener implements Listener {
         if (plugin.isDisabledWorldListener(victim)) {
             return;
         }
+        Entity attacker = event.getDamager();
+        // Check held Material Blacklist
+        if (attacker instanceof Player) {
+            Player player = (Player) attacker;
+            ItemStack item = CMIItemStack.getItemInMainHand(player);
+            if (item != null && !plugin.getItemManager().isAllowed(item.getType(), player) && !ResAdmin.isResAdmin(player)) {
+                lm.General_ItemBlacklisted.sendMessage(player);
+                event.setCancelled(true);
+                return;
+            }
+        }
         // Decorative entity damage uses separate logic
         if (victim instanceof EnderCrystal || victim instanceof ItemFrame || Utils.isArmorStand(victim)) {
             handleDecorativeEntityDamage(event);
             return;
         }
-        Entity attacker = event.getDamager();
         Flags mainFlag = null;
         Flags subFlag = null;
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_08.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_08.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.bukkit.block.Block;
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -15,11 +16,8 @@ import org.bukkit.event.player.PlayerUnleashEntityEvent;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.containers.ResAdmin;
-import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
-import com.bekvon.bukkit.residence.utils.Utils;
 
 public class ResidenceListener1_08 implements Listener {
 
@@ -31,53 +29,34 @@ public class ResidenceListener1_08 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerInteractAtArmoStand(PlayerInteractAtEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.container.isGlobalyEnabled())
-            return;
 
         Player player = event.getPlayer();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(player.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.container, player)) {
+            return;
+        }
         Entity ent = event.getRightClicked();
-        if (!Utils.isArmorStandEntity(ent.getType()))
+
+        if (!(ent instanceof ArmorStand)) {
             return;
-
-        if (ResAdmin.isResAdmin(player))
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(ent.getLocation(), player);
-
-        if (!perms.playerHas(player, Flags.container, perms.playerHas(player, Flags.use, true))) {
+        }
+        if (FlagPermissions.shouldDenyAndNotify(player, ent, Flags.container, Flags.use)) {
             event.setCancelled(true);
-            lm.Flag_Deny.sendMessage(player, Flags.container);
         }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void AnimalUnleash(PlayerUnleashEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.leash.isGlobalyEnabled())
-            return;
 
         Entity entity = event.getEntity();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.leash, entity)) {
+            return;
+        }
         Player player = event.getPlayer();
-
-        if (ResAdmin.isResAdmin(player))
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation(), player);
-        if (perms.playerHas(player, Flags.leash, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.leash);
-
-        event.setCancelled(true);
+        if (FlagPermissions.shouldDenyAndNotify(player, entity, Flags.leash, null)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_08.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_08.java
@@ -72,7 +72,7 @@ public class ResidenceListener1_08 implements Listener {
         }
         Block sourceBlock = event.getBlock();
         // disabling event on world
-        if (plugin.isDisabledWorldListener(sourceBlock.getWorld())) {
+        if (plugin.isDisabledWorldListener(sourceBlock)) {
             return;
         }
         if (Flags.explode.isGlobalyEnabled()) {

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_08.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_08.java
@@ -19,6 +19,8 @@ import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 
+import net.Zrips.CMILib.Version.Version;
+
 public class ResidenceListener1_08 implements Listener {
 
     private Residence plugin;
@@ -61,7 +63,13 @@ public class ResidenceListener1_08 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockExplodeEvent(BlockExplodeEvent event) {
-
+        // ExplosionResult.TRIGGER_BLOCK does not destroy blocks
+        // it is triggered by (Enchantment: Wind Burst)
+        if (Version.isCurrentEqualOrHigher(Version.v1_21_0)
+                && event.getExplosionResult() == org.bukkit.ExplosionResult.TRIGGER_BLOCK) {
+            ResidenceListener1_21.onWindExplode(event);
+            return;
+        }
         Block sourceBlock = event.getBlock();
         // disabling event on world
         if (plugin.isDisabledWorldListener(sourceBlock.getWorld())) {
@@ -84,8 +92,8 @@ public class ResidenceListener1_08 implements Listener {
                 preserve.add(block);
             }
         }
-        for (Block block : preserve) {
-            event.blockList().remove(block);
+        if (!preserve.isEmpty()) {
+            event.blockList().removeAll(preserve);
         }
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_09.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_09.java
@@ -9,13 +9,11 @@ import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.Snowman;
 import org.bukkit.entity.ThrownPotion;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.CauldronLevelChangeEvent;
-import org.bukkit.event.block.EntityBlockFormEvent;
 import org.bukkit.event.entity.AreaEffectCloudApplyEvent;
 import org.bukkit.event.entity.EntityToggleGlideEvent;
 import org.bukkit.event.entity.LingeringPotionSplashEvent;
@@ -26,7 +24,6 @@ import org.bukkit.potion.PotionEffect;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.event.ResidenceChangedEvent;
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
@@ -198,46 +195,6 @@ public class ResidenceListener1_09 implements Listener {
                 event.getEntity().remove();
                 break;
             }
-        }
-    }
-
-    // FrostWalker form frosted_ice, Wither form wither_rose
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onEntityBlockFormEvent(EntityBlockFormEvent event) {
-
-        Entity entity = event.getEntity();
-        if (entity == null)
-            return;
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.build, entity)) {
-            return;
-        }
-        if (entity instanceof Player) {
-            Player player = (Player) entity;
-
-            if (player.hasMetadata("NPC"))
-                return;
-
-            if (ResAdmin.isResAdmin(player))
-                return;
-
-            FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation(), player);
-            if (perms.playerHas(player, Flags.build, true))
-                return;
-
-            event.setCancelled(true);
-
-            // SnowGolem already has SnowTrail Flag
-            // Check all entity trigger FrostWalker
-            // ArmorStand Skeleton Zombies ...
-        } else if (!(entity instanceof Snowman)) {
-
-            FlagPermissions perms = FlagPermissions.getPerms(event.getBlock().getLocation());
-            if (perms.has(Flags.build, true))
-                return;
-
-            event.setCancelled(true);
-
         }
     }
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_09.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_09.java
@@ -19,7 +19,6 @@ import org.bukkit.event.block.EntityBlockFormEvent;
 import org.bukkit.event.entity.AreaEffectCloudApplyEvent;
 import org.bukkit.event.entity.EntityToggleGlideEvent;
 import org.bukkit.event.entity.LingeringPotionSplashEvent;
-import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.EquipmentSlot;
@@ -49,36 +48,25 @@ public class ResidenceListener1_09 implements Listener {
 
     @EventHandler
     public void EntityToggleGlideEvent(EntityToggleGlideEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.elytra.isGlobalyEnabled())
-            return;
 
         Entity entity = event.getEntity();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.elytra, entity)) {
+            return;
+        }
         if (!(entity instanceof Player))
             return;
 
         Player player = (Player) entity;
 
-        if (ResAdmin.isResAdmin(player))
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(player);
-
-        if (perms.playerHas(player, Flags.elytra, FlagCombo.TrueOrNone))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.elytra);
-
-        event.setCancelled(true);
-        CMIScheduler.runAtLocation(plugin, player.getLocation(), () -> {
-            // Need to enable before disabling to prevent client side bug
-            player.setGliding(true);
-            player.setGliding(false);
-        });
+        if (FlagPermissions.shouldDenyAndNotify(player, player, Flags.elytra, null)) {
+            event.setCancelled(true);
+            CMIScheduler.runAtLocation(plugin, player.getLocation(), () -> {
+                // Need to enable before disabling to prevent client side bug
+                player.setGliding(true);
+                player.setGliding(false);
+            });
+        }
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -87,8 +75,6 @@ public class ResidenceListener1_09 implements Listener {
         if (!Flags.elytra.isGlobalyEnabled())
             return;
 
-        ClaimedResidence newRes = event.getTo();
-
         Player player = event.getPlayer();
         if (player == null)
             return;
@@ -96,6 +82,7 @@ public class ResidenceListener1_09 implements Listener {
         if (!player.isGliding())
             return;
 
+        ClaimedResidence newRes = event.getTo();
         if (newRes == null)
             return;
 
@@ -125,16 +112,12 @@ public class ResidenceListener1_09 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onLingeringSplashPotion(LingeringPotionSplashEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.pvp.isGlobalyEnabled())
-            return;
 
-        ProjectileHitEvent ev = event;
-        ThrownPotion potion = (ThrownPotion) ev.getEntity();
+        ThrownPotion potion = event.getEntity();
 
-        // disabling event on world
-        if (Residence.getInstance().isDisabledWorldListener(potion.getWorld()))
+        if (FlagPermissions.shouldIgnoreCheck(Flags.pvp, potion)) {
             return;
+        }
 
         boolean harmfull = false;
         mein: for (PotionEffect one : potion.getEffects()) {
@@ -148,8 +131,7 @@ public class ResidenceListener1_09 implements Listener {
         if (!harmfull)
             return;
 
-        Entity ent = potion;
-        boolean srcpvp = FlagPermissions.has(ent.getLocation(), Flags.pvp, FlagCombo.TrueOrNone);
+        boolean srcpvp = FlagPermissions.has(potion.getLocation(), Flags.pvp, FlagCombo.TrueOrNone);
         if (!srcpvp)
             event.setCancelled(true);
     }
@@ -159,13 +141,10 @@ public class ResidenceListener1_09 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onLingeringEffectApply(AreaEffectCloudApplyEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.pvp.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (Residence.getInstance().isDisabledWorldListener(event.getEntity().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.pvp, event.getEntity())) {
+            return;
+        }
         boolean harmfull = false;
 
         // Temporally fail safe to avoid console spam for getting base potion data until
@@ -225,17 +204,14 @@ public class ResidenceListener1_09 implements Listener {
     // FrostWalker form frosted_ice, Wither form wither_rose
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityBlockFormEvent(EntityBlockFormEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.build.isGlobalyEnabled())
-            return;
 
         Entity entity = event.getEntity();
         if (entity == null)
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.build, entity)) {
+            return;
+        }
         if (entity instanceof Player) {
             Player player = (Player) entity;
 
@@ -267,58 +243,39 @@ public class ResidenceListener1_09 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerEatChorusFruit(PlayerItemConsumeEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.chorustp.isGlobalyEnabled())
-            return;
 
         Player player = event.getPlayer();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(player.getWorld()))
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.chorustp, player)) {
             return;
-
-        CMIMaterial cmat = CMIMaterial.get(event.getItem());
-
-        if (cmat.equals(CMIMaterial.CHORUS_FRUIT)) {
-
-            if (player.hasMetadata("NPC") || ResAdmin.isResAdmin(player))
-                return;
-
-            if (FlagPermissions.has(player.getLocation(), player, Flags.chorustp, true))
-                return;
-
-            lm.Flag_Deny.sendMessage(player, Flags.chorustp);
+        }
+        if (CMIMaterial.get(event.getItem()) != CMIMaterial.CHORUS_FRUIT) {
+            return;
+        }
+        if (FlagPermissions.shouldDenyAndNotify(player, player, Flags.chorustp, null)) {
             event.setCancelled(true);
-
         }
     }
 
     // Bucket, glass_bottle, potion, pattern banners & dyed shulker_boxes change cauldron level
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onCauldronLevelChange(CauldronLevelChangeEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.build.isGlobalyEnabled()) {
-            return;
-        }
+
         Entity entity = event.getEntity();
         if (entity == null) {
             return;
         }
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld())) {
+        if (FlagPermissions.shouldIgnoreCheck(Flags.build, entity)) {
             return;
         }
         if (!(entity instanceof Player)) {
             return;
         }
         Player player = (Player) entity;
-        if (ResAdmin.isResAdmin(player)) {
-            return;
+
+        if (FlagPermissions.shouldDenyAndNotify(player, event.getBlock(), Flags.build, null)) {
+            event.setCancelled(true);
         }
-        if (FlagPermissions.has(event.getBlock().getLocation(), player, Flags.build, true)) {
-            return;
-        }
-        lm.Flag_Deny.sendMessage(player, Flags.build);
-        event.setCancelled(true);
     }
 
     // Supported 1.9+

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_10.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_10.java
@@ -21,17 +21,15 @@ public class ResidenceListener1_10 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityHotFloorDamage(EntityDamageEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.hotfloor.isGlobalyEnabled())
+
+        Entity ent = event.getEntity();
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.hotfloor, event.getEntity())) {
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
-            return;
+        }
 
         if (event.getCause() != DamageCause.HOT_FLOOR)
             return;
-
-        Entity ent = event.getEntity();
 
         if (!FlagPermissions.has(ent.getLocation(), Flags.hotfloor, true)) {
             event.setCancelled(true);

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_12.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_12.java
@@ -26,14 +26,10 @@ public class ResidenceListener1_12 implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onEntityPickupItemEvent(EntityPickupItemEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.itempickup.isGlobalyEnabled())
-            return;
 
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getItem().getWorld()))
+        if (FlagPermissions.shouldIgnoreCheck(Flags.itempickup, event.getItem())) {
             return;
-
+        }
         Entity entity = event.getEntity();
         if (entity.hasMetadata("NPC"))
             return;
@@ -62,22 +58,18 @@ public class ResidenceListener1_12 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerItemDamageEvent(PlayerItemDamageEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.nodurability.isGlobalyEnabled())
-            return;
 
         Player player = event.getPlayer();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(player.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.nodurability, player)) {
+            return;
+        }
         if (FlagPermissions.has(player.getLocation(), Flags.nodurability, FlagCombo.FalseOrNone))
             return;
 
-        CMIMaterial held = CMIMaterial.get(event.getItem());
         // https://github.com/Zrips/Residence/issues/359
         // not sure if we need to keep this check line
-        if (held == CMIMaterial.TRIDENT)
+        if (CMIMaterial.get(event.getItem()) == CMIMaterial.TRIDENT)
             return;
 
         event.setCancelled(true);

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
@@ -80,7 +80,7 @@ public class ResidenceListener1_13 implements Listener {
     private boolean shouldCancelFarmLandChange(Block block) {
 
         // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
+        if (plugin.isDisabledWorldListener(block))
             return false;
 
         if (block.getType() != Material.FARMLAND)
@@ -105,7 +105,7 @@ public class ResidenceListener1_13 implements Listener {
             return;
         }
         // disabling event on world
-        if (plugin.isDisabledWorldListener(hitBlock.getWorld())) {
+        if (plugin.isDisabledWorldListener(hitBlock)) {
             return;
         }
         Block hitBlockFace = hitBlock.getLocation().clone().add(event.getHitBlockFace().getDirection()).getBlock();

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_13.java
@@ -142,15 +142,12 @@ public class ResidenceListener1_13 implements Listener {
         // 1.17+ has PlayerBucketEntityEvent
         if (Version.isCurrentEqualOrHigher(Version.v1_17_R1))
             return;
-        // Disabling listener if flag disabled globally
-        if (!Flags.animalkilling.isGlobalyEnabled())
-            return;
 
         Entity ent = event.getRightClicked();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.animalkilling, ent)) {
+            return;
+        }
         if (!(ent instanceof Fish))
             return;
 
@@ -161,14 +158,8 @@ public class ResidenceListener1_13 implements Listener {
         if (held != Material.WATER_BUCKET)
             return;
 
-        if (ResAdmin.isResAdmin(player))
-            return;
-
-        if (FlagPermissions.has(ent.getLocation(), player, Flags.animalkilling, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.animalkilling);
-        event.setCancelled(true);
-
+        if (FlagPermissions.shouldDenyAndNotify(player, ent, Flags.animalkilling, null)) {
+            event.setCancelled(true);
+        }
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
@@ -24,7 +24,6 @@ import org.bukkit.event.vehicle.VehicleDamageEvent;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
@@ -116,14 +115,7 @@ public class ResidenceListener1_14 implements Listener {
         Player player = Utils.potentialProjectileToPlayer(projectile);
         if (player != null) {
 
-            if (ResAdmin.isResAdmin(player)) {
-                return false;
-            }
-            if (FlagPermissions.has(block.getLocation(), player, flag, FlagCombo.OnlyFalse)) {
-                lm.Flag_Deny.sendMessage(player, flag);
-                return true;
-            }
-            return false;
+            return FlagPermissions.shouldDenyAndNotify(player, block, flag, null);
 
         } else {
             // projectile not player source

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_14.java
@@ -4,7 +4,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
@@ -66,68 +65,43 @@ public class ResidenceListener1_14 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onLecternBookTake(PlayerTakeLecternBookEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.container.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getLectern().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.container, event.getLectern().getWorld())) {
+            return;
+        }
         Player player = event.getPlayer();
 
-        if (ResAdmin.isResAdmin(player))
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(event.getLectern().getLocation(), player);
-        if (perms.playerHas(player, Flags.container, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.container);
-
-        event.setCancelled(true);
-
+        if (FlagPermissions.shouldDenyAndNotify(player, event.getLectern().getLocation(), Flags.container, null)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onVehicleDamage(VehicleDamageEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.vehicledestroy.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getVehicle().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.vehicledestroy, event.getVehicle())) {
+            return;
+        }
         Entity attacker = event.getAttacker();
-        if (attacker instanceof Player) {
 
-            Player player = (Player) attacker;
+        if (!(attacker instanceof Player)) {
+            return;
+        }
+        Player player = (Player) attacker;
 
-            if (ResAdmin.isResAdmin(player))
-                return;
-
-            FlagPermissions perms = FlagPermissions.getPerms(event.getVehicle().getLocation(), player);
-            if (perms.playerHas(player, Flags.vehicledestroy, true))
-                return;
-
-            lm.Flag_Deny.sendMessage(player, Flags.vehicledestroy);
-
+        if (FlagPermissions.shouldDenyAndNotify(player, event.getVehicle(), Flags.vehicledestroy, null)) {
             event.setCancelled(true);
-
         }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onProjectileHitBell(ProjectileHitEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.use.isGlobalyEnabled()) {
-            return;
-        }
+
         Block block = event.getHitBlock();
         if (block == null) {
             return;
         }
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld())) {
+        if (FlagPermissions.shouldIgnoreCheck(Flags.use, block)) {
             return;
         }
         if (block.getType() != Material.BELL) {
@@ -164,16 +138,14 @@ public class ResidenceListener1_14 implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPlayerInteractHarvest(PlayerInteractEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.harvest.isGlobalyEnabled())
-            return;
 
         Block block = event.getClickedBlock();
         if (block == null)
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.harvest, block)) {
             return;
+        }
 
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK)
             return;
@@ -190,28 +162,20 @@ public class ResidenceListener1_14 implements Listener {
         }
 
         Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player))
-            return;
 
-        if (FlagPermissions.has(block.getLocation(), player, Flags.harvest, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.harvest);
-        event.setCancelled(true);
-
+        if (FlagPermissions.shouldDenyAndNotify(player, block, Flags.harvest, null)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onCoralDryFade(BlockFadeEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.coraldryup.isGlobalyEnabled())
-            return;
 
         Block block = event.getBlock();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.coraldryup, block)) {
+            return;
+        }
         Material mat = block.getType();
 
         if (!(isBlockTag(mat, "corals") || isBlockTag(mat, "coral_blocks") || isBlockTag(mat, "wall_corals")))
@@ -224,16 +188,11 @@ public class ResidenceListener1_14 implements Listener {
 
 	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void onVanillaRaidTrigger(RaidTriggerEvent event) {
-		// Disabling listener if flag disabled globally
-		if (!Flags.raid.isGlobalyEnabled()) {
-			return;
-		}
-		Location raidLoc = event.getRaid().getLocation();
-		// disabling event on world
-		if (plugin.isDisabledWorldListener(raidLoc.getWorld())) {
-			return;
-		}
-        if (FlagPermissions.has(raidLoc, Flags.raid, true)) {
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.raid, event.getWorld())) {
+            return;
+        }
+        if (FlagPermissions.has(event.getRaid().getLocation(), Flags.raid, true)) {
             return;
         }
         lm.Flag_Deny.sendMessage(event.getPlayer(), Flags.raid);

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_15.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_15.java
@@ -11,8 +11,6 @@ import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.containers.lm;
-import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 
 import net.Zrips.CMILib.CMILib;
@@ -29,17 +27,14 @@ public class ResidenceListener1_15 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerInteractBeeHive(PlayerInteractEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.build.isGlobalyEnabled())
-            return;
 
         Block block = event.getClickedBlock();
         if (block == null)
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.build, block)) {
+            return;
+        }
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK)
             return;
 
@@ -68,15 +63,9 @@ public class ResidenceListener1_15 implements Listener {
         }
 
         Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player))
-            return;
 
-        FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
-        if (perms.playerHas(player, flag, perms.playerHas(player, Flags.build, true)))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, flag);
-        event.setCancelled(true);
-
+        if (FlagPermissions.shouldDenyAndNotify(player, block, flag, Flags.build)) {
+            event.setCancelled(true);
+        }
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16.java
@@ -31,13 +31,9 @@ public class ResidenceListener1_16 implements Listener {
                 return;
             }
         }
-        // Disabling listener if flag disabled globally
-        if (!Flags.animalkilling.isGlobalyEnabled()) {
-            return;
-        }
         Entity entity = event.getEntity();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld())) {
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.animalkilling, entity)) {
             return;
         }
         if (event.getTransformReason() != EntityTransformEvent.TransformReason.LIGHTNING) {

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16_5_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_16_5_Paper.java
@@ -29,16 +29,12 @@ public class ResidenceListener1_16_5_Paper implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onHitTargetBlock(TargetHitEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.use.isGlobalyEnabled()) {
-            return;
-        }
+
         Block block = event.getHitBlock();
         if (block == null) {
             return;
         }
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld())) {
+        if (FlagPermissions.shouldIgnoreCheck(Flags.use, block)) {
             return;
         }
         if (ResidenceListener1_14.shouldDenyProjectileHit(block, event.getEntity(), Flags.use)) {
@@ -48,13 +44,10 @@ public class ResidenceListener1_16_5_Paper implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onEntityZapEvent(EntityZapEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.animalkilling.isGlobalyEnabled()) {
-            return;
-        }
+
         Entity entity = event.getEntity();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld())) {
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.animalkilling, entity)) {
             return;
         }
         // Check if animal can be damaged or converted by lightning

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_17.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_17.java
@@ -151,9 +151,9 @@ public class ResidenceListener1_17 implements Listener {
         // check build permission for spread blocks
         ClaimedResidence originRes = ClaimedResidence.getByLoc(block.getLocation());
 
-        List<BlockState> blocks = new ArrayList<BlockState>(event.getBlocks());
+        List<BlockState> denySpread = new ArrayList<>();
 
-        for (BlockState oneBlock : blocks) {
+        for (BlockState oneBlock : event.getBlocks()) {
             ClaimedResidence spreadRes = ClaimedResidence.getByLoc(oneBlock.getLocation());
             // spread-block not in Res, skip check
             // origin & spread-block in Same Res, or have Same Res owner, skip check
@@ -164,14 +164,17 @@ public class ResidenceListener1_17 implements Listener {
             // origin & spread-block not in Same Res, not Same Res owner
 
             if (player != null) {
-                if (spreadRes.getPermissions().playerHas(player, Flags.build, FlagCombo.OnlyFalse))
-                    event.getBlocks().remove(oneBlock);
-
-            } else if (spreadRes.getPermissions().has(Flags.build, FlagCombo.OnlyFalse)) {
-                event.getBlocks().remove(oneBlock);
-
+                if (spreadRes.getPermissions().playerHas(player, Flags.build, FlagCombo.OnlyFalse)) {
+                    denySpread.add(oneBlock);
+                }
+            } else {
+                if (spreadRes.getPermissions().has(Flags.build, FlagCombo.OnlyFalse)) {
+                    denySpread.add(oneBlock);
+                }
             }
         }
-
+        if (!denySpread.isEmpty()) {
+            event.getBlocks().removeAll(denySpread);
+        }
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_17.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_17.java
@@ -19,7 +19,6 @@ import org.bukkit.event.player.PlayerBucketEntityEvent;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.containers.ResidenceBlockData;
 import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.permissions.PermissionManager.ResPerm;
@@ -62,34 +61,25 @@ public class ResidenceListener1_17 implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPlayerBucketEntityEvent(PlayerBucketEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.animalkilling.isGlobalyEnabled())
-            return;
 
         Entity ent = event.getEntity();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.animalkilling, ent)) {
+            return;
+        }
         Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player))
-            return;
 
-        if (FlagPermissions.has(ent.getLocation(), player, Flags.animalkilling, FlagCombo.OnlyFalse)) {
-            lm.Flag_Deny.sendMessage(player, Flags.animalkilling);
+        if (FlagPermissions.shouldDenyAndNotify(player, ent, Flags.animalkilling, null)) {
             event.setCancelled(true);
         }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onCopperOxidation(BlockFormEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.copperoxidation.isGlobalyEnabled()) {
-            return;
-        }
+
         Block block = event.getBlock();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld())) {
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.copperoxidation, block)) {
             return;
         }
         if (!isUnwaxedCopper(block)) {
@@ -113,13 +103,10 @@ public class ResidenceListener1_17 implements Listener {
         // https://github.com/PaperMC/Paper/pull/6751
         if (Version.isPaperBranch() && Version.isCurrentEqualOrHigher(Version.v1_18_R2))
             return;
-        // Disabling listener if flag disabled globally
-        if (!Flags.place.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.place, event.getBlock())) {
+            return;
+        }
         if (!event.getSourceBlock().getType().equals(Material.POWDER_SNOW) || event.getBlock().getType().equals(Material.AIR) || event.getBlock().getType().equals(Material.POWDER_SNOW))
             return;
 
@@ -141,14 +128,11 @@ public class ResidenceListener1_17 implements Listener {
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onBlockFertilizeEvent(BlockFertilizeEvent event) {
 
-        // Disabling listener if flag disabled globally
-        if (!Flags.build.isGlobalyEnabled())
-            return;
         Block block = event.getBlock();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.build, block)) {
+            return;
+        }
         Player player = event.getPlayer();
 
         if (player != null) {

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
@@ -17,11 +17,8 @@ import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.containers.ResAdmin;
-import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
-import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 
 import net.Zrips.CMILib.Items.CMIMaterial;
 import net.Zrips.CMILib.Version.Version;
@@ -36,41 +33,29 @@ public class ResidenceListener1_19 implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onUseGoatHorn(PlayerInteractEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.goathorn.isGlobalyEnabled())
-            return;
 
         Player player = event.getPlayer();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(player.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.goathorn, player)) {
+            return;
+        }
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK)
             return;
 
         if (CMIMaterial.get(event.getItem()) != CMIMaterial.GOAT_HORN)
             return;
 
-        if (player.hasMetadata("NPC") || ResAdmin.isResAdmin(player))
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(player.getLocation(), player);
-        if (perms.playerHas(player, Flags.goathorn, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.goathorn);
-        event.setCancelled(true);
+        if (FlagPermissions.shouldDenyAndNotify(player, player, Flags.goathorn, null)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onBlockSpread(BlockSpreadEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.skulk.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getBlock().getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.skulk, event.getBlock())) {
+            return;
+        }
         if (!Material.SCULK_CATALYST.equals(event.getSource().getType()))
             return;
 
@@ -129,26 +114,18 @@ public class ResidenceListener1_19 implements Listener {
     // riding InventoryVehicle: check Flag_container when opening Vehicle Inventory
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerOpenVehicleInv(InventoryOpenEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.container.isGlobalyEnabled())
-            return;
 
         Player player = (Player) event.getPlayer();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(player.getWorld()))
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.container, player)) {
             return;
-
+        }
         Entity vehicle = player.getVehicle();
-        if (canHaveContainer1_19(vehicle)) {
 
-            if (ResAdmin.isResAdmin(player))
-                return;
-
-            FlagPermissions perms = FlagPermissions.getPerms(vehicle.getLocation(), player);
-            if (perms.playerHas(player, Flags.container, true))
-                return;
-
-            lm.Flag_Deny.sendMessage(player, Flags.container);
+        if (!canHaveContainer1_19(vehicle)) {
+            return;
+        }
+        if (FlagPermissions.shouldDenyAndNotify(player, vehicle, Flags.container, null)) {
             event.setCancelled(true);
         }
     }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
@@ -6,10 +6,10 @@ import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.ChestBoat;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.Action;
-import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockSpreadEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
@@ -17,10 +17,8 @@ import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 
-import net.Zrips.CMILib.Items.CMIMaterial;
 import net.Zrips.CMILib.Version.Version;
 
 public class ResidenceListener1_19 implements Listener {
@@ -31,9 +29,11 @@ public class ResidenceListener1_19 implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.NORMAL)
     public void onUseGoatHorn(PlayerInteractEvent event) {
-
+        if (event.useItemInHand() == Result.DENY) {
+            return;
+        }
         Player player = event.getPlayer();
 
         if (FlagPermissions.shouldIgnoreCheck(Flags.goathorn, player)) {
@@ -42,9 +42,9 @@ public class ResidenceListener1_19 implements Listener {
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK)
             return;
 
-        if (CMIMaterial.get(event.getItem()) != CMIMaterial.GOAT_HORN)
+        if (event.getItem() == null || event.getItem().getType() != Material.GOAT_HORN) {
             return;
-
+        }
         if (FlagPermissions.shouldDenyAndNotify(player, player, Flags.goathorn, null)) {
             event.setCancelled(true);
         }
@@ -64,50 +64,6 @@ public class ResidenceListener1_19 implements Listener {
         if (!perms.has(Flags.skulk, true)) {
             event.setCancelled(true);
         }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onHopperCrossRes(InventoryMoveItemEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.container.isGlobalyEnabled())
-            return;
-
-        ClaimedResidence sourceRes = ClaimedResidence.getByLoc(event.getSource().getLocation());
-        ClaimedResidence destRes = ClaimedResidence.getByLoc(event.getDestination().getLocation());
-
-        // source & dest not in Res
-        if (sourceRes == null && destRes == null)
-            return;
-
-        // source & dest in Res
-        if (sourceRes != null && destRes != null) {
-
-            // in Same Res, or have Same Res owner
-            if (sourceRes.equals(destRes) || sourceRes.isOwner(destRes.getOwner()))
-                return;
-
-            // not in Same Res & not Same Res owner
-            // hopper can be source or dest
-            if (sourceRes.getPermissions().has(Flags.container, true) &&
-                    destRes.getPermissions().has(Flags.container, true))
-                return;
-
-            // source in Res, dest definitely not in Res
-        } else if (sourceRes != null) {
-
-            if (sourceRes.getPermissions().has(Flags.container, true))
-                return;
-
-            // dest definitely in Res, source definitely not in Res
-        } else {
-
-            if (destRes.getPermissions().has(Flags.container, true))
-                return;
-
-        }
-
-        event.setCancelled(true);
-
     }
 
     // if Flag_riding is true

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_19.java
@@ -2,9 +2,6 @@ package com.bekvon.bukkit.residence.listeners;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.entity.AbstractHorse;
-import org.bukkit.entity.ChestBoat;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
@@ -12,14 +9,11 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockSpreadEvent;
-import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
-
-import net.Zrips.CMILib.Version.Version;
 
 public class ResidenceListener1_19 implements Listener {
 
@@ -64,35 +58,5 @@ public class ResidenceListener1_19 implements Listener {
         if (!perms.has(Flags.skulk, true)) {
             event.setCancelled(true);
         }
-    }
-
-    // if Flag_riding is true
-    // riding InventoryVehicle: check Flag_container when opening Vehicle Inventory
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onPlayerOpenVehicleInv(InventoryOpenEvent event) {
-
-        Player player = (Player) event.getPlayer();
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.container, player)) {
-            return;
-        }
-        Entity vehicle = player.getVehicle();
-
-        if (!canHaveContainer1_19(vehicle)) {
-            return;
-        }
-        if (FlagPermissions.shouldDenyAndNotify(player, vehicle, Flags.container, null)) {
-            event.setCancelled(true);
-        }
-    }
-
-    // Cover All 1.19+ Vehicles with an Inventory interface
-    public static boolean canHaveContainer1_19(Entity entity) {
-        if (entity == null) {
-            return false;
-        }
-        return entity instanceof AbstractHorse
-                || entity instanceof ChestBoat
-                || (Version.isCurrentEqualOrHigher(Version.v1_21_R7) && entity instanceof org.bukkit.entity.AbstractNautilus);
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_20.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_20.java
@@ -8,10 +8,7 @@ import org.bukkit.event.player.PlayerSignOpenEvent;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.containers.ResAdmin;
-import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
-import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 
 public class ResidenceListener1_20 implements Listener {
 
@@ -23,32 +20,14 @@ public class ResidenceListener1_20 implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onSignInteract(PlayerSignOpenEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.build.isGlobalyEnabled())
-            return;
 
         Player player = event.getPlayer();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(player.getWorld()))
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.build, player)) {
             return;
-
-        if (player.hasMetadata("NPC"))
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(event.getSign().getLocation(), player);
-
-        boolean hasUse = perms.playerHas(player, Flags.use, FlagCombo.TrueOrNone);
-        boolean hasBuild = perms.playerHas(player, Flags.build, FlagCombo.TrueOrNone);
-
-        if (hasUse && hasBuild || ResAdmin.isResAdmin(player))
-            return;
-
-        event.setCancelled(true);
-
-        if (!hasUse)
-            lm.Flag_Deny.sendMessage(player, Flags.use);
-        else
-            lm.Flag_Deny.sendMessage(player, Flags.build);
-
+        }
+        if (FlagPermissions.shouldDenyAndNotify(player, event.getSign().getLocation(), Flags.build, Flags.use)) {
+            event.setCancelled(true);
+        }
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -38,7 +38,6 @@ import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.containers.lm;
-import com.bekvon.bukkit.residence.listenersCache.DenyMessageCache;
 import com.bekvon.bukkit.residence.protection.ClaimedResidence;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
@@ -114,9 +113,7 @@ public class ResidenceListener1_21 implements Listener {
             return;
         }
         if (res.getPermissions().playerHas(closest, Flags.leash, FlagCombo.OnlyFalse)) {
-            if (DenyMessageCache.shouldSendDenyMessage(closest, Flags.leash)) {
-                lm.Residence_FlagDeny.sendMessage(closest, Flags.leash, res.getName());
-            }
+            lm.Residence_FlagDeny.sendMessage(closest, Flags.leash, res.getName());
             event.setCancelled(true);
         }
     }
@@ -141,29 +138,40 @@ public class ResidenceListener1_21 implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
-    public void OnEntityDeath(EntityDeathEvent event) {
+    public void onWeavingEffectTrigger(EntityDeathEvent event) {
 
         LivingEntity ent = event.getEntity();
-        if (ent == null)
-            return;
 
-        if (FlagPermissions.shouldIgnoreCheck(Flags.build, ent)) {
+        if (plugin.isDisabledWorldListener(ent.getWorld())) {
             return;
         }
         if (!ent.hasPotionEffect(PotionEffectType.WEAVING))
             return;
 
-        if (ent instanceof Player) {
-
-            Player player = (Player) ent;
-            if (ResAdmin.isResAdmin(player)) {
-                return;
-            }
-            if (FlagPermissions.has(ent.getLocation(), player, Flags.build, true)) {
+        if (Flags.animalgriefing.isGlobalyEnabled() && Utils.isAnimal(ent)) {
+            FlagPermissions perms = FlagPermissions.getPerms(ent.getLocation());
+            if (perms.has(Flags.animalgriefing, perms.has(Flags.build, true))) {
                 return;
             }
 
-        } else if (FlagPermissions.has(ent.getLocation(), Flags.build, true)) {
+        } else if (Flags.mobgriefing.isGlobalyEnabled() && ResidenceEntityListener.isMonster(ent)) {
+            FlagPermissions perms = FlagPermissions.getPerms(ent.getLocation());
+            if (perms.has(Flags.mobgriefing, perms.has(Flags.build, true))) {
+                return;
+            }
+
+        } else if (Flags.build.isGlobalyEnabled()) {
+            if (ent instanceof Player) {
+                Player player = (Player) ent;
+                if (!FlagPermissions.shouldDenyAndNotify(player, player, Flags.build, null)) {
+                    return;
+                }
+            } else {
+                if (FlagPermissions.has(ent.getLocation(), Flags.build, true)) {
+                    return;
+                }
+            }
+        } else {
             return;
         }
         // Removing weaving effect on death as there is no other way to properly handle
@@ -510,9 +518,7 @@ public class ResidenceListener1_21 implements Listener {
                     ? perms.has(subFlag, true)
                     : playerPerms.playerHas(player, subFlag, true);
             if (!playerPerms.playerHas(player, mainFlag, result)) {
-                if (DenyMessageCache.shouldSendDenyMessage(player, mainFlag)) {
-                    lm.Flag_Deny.sendMessage(player, mainFlag);
-                }
+                lm.Flag_Deny.sendMessage(player, mainFlag);
                 sholudDeny = true;
             }
         } else {

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -50,15 +50,12 @@ public class ResidenceListener1_21 implements Listener {
     // Prevent player from taking away animals in Residence by pulling boat
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onAnimalEntersLeashedBoat(VehicleEnterEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.leash.isGlobalyEnabled())
-            return;
 
         Entity vehicle = event.getVehicle();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(vehicle.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.leash, vehicle)) {
+            return;
+        }
         if (!(vehicle instanceof Boat))
             return;
 
@@ -116,15 +113,12 @@ public class ResidenceListener1_21 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onAnimalEnterVehicle(VehicleEnterEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.boarding.isGlobalyEnabled())
-            return;
 
         Entity entity = event.getEntered();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.boarding, entity)) {
+            return;
+        }
         if (!(entity instanceof LivingEntity))
             return;
 
@@ -138,15 +132,14 @@ public class ResidenceListener1_21 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void OnEntityDeath(EntityDeathEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.build.isGlobalyEnabled())
-            return;
-        // disabling event on world
+
         LivingEntity ent = event.getEntity();
         if (ent == null)
             return;
-        if (plugin.isDisabledWorldListener(ent.getWorld()))
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.build, ent)) {
             return;
+        }
         if (!ent.hasPotionEffect(PotionEffectType.WEAVING))
             return;
 
@@ -170,36 +163,25 @@ public class ResidenceListener1_21 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onInteractCopperGolem(PlayerInteractEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.copper.isGlobalyEnabled())
-            return;
 
         Entity entity = event.getRightClicked();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.copper, entity)) {
+            return;
+        }
         if (CMIEntityType.get(entity) != CMIEntityType.COPPER_GOLEM)
             return;
 
         Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player))
-            return;
 
-        if (entity instanceof LivingEntity) {
+        EntityEquipment gloemInv = ((LivingEntity) entity).getEquipment();
+        // Right-click to remove items from holding copper_golem
+        if (gloemInv != null && (gloemInv.getItemInMainHand().getType() != Material.AIR)) {
 
-            EntityEquipment gloemInv = ((LivingEntity) entity).getEquipment();
-            // Right-click to remove items from holding copper_golem
-            if (gloemInv != null && (gloemInv.getItemInMainHand().getType() != Material.AIR ||
-                    gloemInv.getItemInOffHand().getType() != Material.AIR)) {
-
-                if (FlagPermissions.has(entity.getLocation(), player, Flags.container, true))
-                    return;
-
-                lm.Flag_Deny.sendMessage(player, Flags.container);
+            if (FlagPermissions.shouldDenyAndNotify(player, entity, Flags.container, null)) {
                 event.setCancelled(true);
-                return;
             }
+            return;
         }
         // Copper_golem has no item in hand
 
@@ -209,27 +191,21 @@ public class ResidenceListener1_21 implements Listener {
         if (held != Material.HONEYCOMB && !isItemTag(held, "axes"))
             return;
 
-        FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation(), player);
-        if (perms.playerHas(player, Flags.copper, perms.playerHas(player, Flags.animalkilling, true)))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.copper);
-        event.setCancelled(true);
+        if (FlagPermissions.shouldDenyAndNotify(player, entity, Flags.copper, Flags.animalkilling)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onFishingBobberHit(ProjectileHitEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.hook.isGlobalyEnabled())
-            return;
         // anti NPE
-        Entity HitEntity = event.getHitEntity();
-        if (HitEntity == null)
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(HitEntity.getWorld()))
+        Entity hitEntity = event.getHitEntity();
+        if (hitEntity == null)
             return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.hook, hitEntity)) {
+            return;
+        }
         Projectile hook = event.getEntity();
         // only fishing_bobber
         if (CMIEntityType.get(hook) != CMIEntityType.FISHING_BOBBER)
@@ -239,28 +215,20 @@ public class ResidenceListener1_21 implements Listener {
             return;
 
         Player player = (Player) hook.getShooter();
-        if (ResAdmin.isResAdmin(player))
-            return;
 
-        FlagPermissions perms = FlagPermissions.getPerms(HitEntity.getLocation(), player);
-        if (perms.playerHas(player, Flags.hook, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.hook);
-        event.setCancelled(true);
+        if (FlagPermissions.shouldDenyAndNotify(player, hitEntity, Flags.hook, null)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onAnimalFeeding(PlayerInteractEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.animalfeeding.isGlobalyEnabled())
-            return;
 
         Entity entity = event.getRightClicked();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.animalfeeding, entity)) {
+            return;
+        }
         if (!(entity instanceof Mob))
             return;
 
@@ -270,16 +238,10 @@ public class ResidenceListener1_21 implements Listener {
             return;
 
         Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player))
-            return;
 
-        FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation(), player);
-        if (perms.playerHas(player, Flags.animalfeeding, perms.playerHas(player, Flags.animalkilling, true)))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.animalfeeding);
-        event.setCancelled(true);
-
+        if (FlagPermissions.shouldDenyAndNotify(player, entity, Flags.animalfeeding, Flags.animalkilling)) {
+            event.setCancelled(true);
+        }
     }
 
     private boolean isFeedingAnimal(Mob entity, Material held) {
@@ -365,15 +327,12 @@ public class ResidenceListener1_21 implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
     public void onPlayerEquipAnimal(PlayerInteractEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.container.isGlobalyEnabled())
-            return;
 
         Entity entity = event.getRightClicked();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.container, entity)) {
+            return;
+        }
         if (!(entity instanceof Animals))
             return;
 
@@ -385,15 +344,10 @@ public class ResidenceListener1_21 implements Listener {
             return;
 
         Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player))
-            return;
 
-        if (FlagPermissions.has(entity.getLocation(), player, Flags.container, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.container);
-        event.setCancelled(true);
-
+        if (FlagPermissions.shouldDenyAndNotify(player, entity, Flags.container, null)) {
+            event.setCancelled(true);
+        }
     }
 
     private boolean isEquipFitAnimal(Animals entity, CMIMaterial held) {

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -142,7 +142,7 @@ public class ResidenceListener1_21 implements Listener {
 
         LivingEntity ent = event.getEntity();
 
-        if (plugin.isDisabledWorldListener(ent.getWorld())) {
+        if (plugin.isDisabledWorldListener(ent)) {
             return;
         }
         if (!ent.hasPotionEffect(PotionEffectType.WEAVING))
@@ -434,7 +434,7 @@ public class ResidenceListener1_21 implements Listener {
 
         Block originBlock = event.getBlock();
 
-        if (Residence.getInstance().isDisabledWorldListener(originBlock.getWorld())) {
+        if (Residence.getInstance().isDisabledWorldListener(originBlock)) {
             return;
         }
         if (Flags.windexplode.isGlobalyEnabled()) {
@@ -466,7 +466,7 @@ public class ResidenceListener1_21 implements Listener {
 
         Entity originEntity = event.getEntity();
 
-        if (Residence.getInstance().isDisabledWorldListener(originEntity.getWorld())) {
+        if (Residence.getInstance().isDisabledWorldListener(originEntity)) {
             return;
         }
         ProjectileSource cause;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -1,7 +1,13 @@
 package com.bekvon.bukkit.residence.listeners;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.AbstractHorse;
+import org.bukkit.entity.AbstractWindCharge;
 import org.bukkit.entity.Ageable;
 import org.bukkit.entity.Animals;
 import org.bukkit.entity.Boat;
@@ -15,7 +21,9 @@ import org.bukkit.entity.Strider;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.vehicle.VehicleEnterEvent;
@@ -23,6 +31,8 @@ import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.projectiles.ProjectileSource;
+import org.jetbrains.annotations.Nullable;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
@@ -410,5 +420,122 @@ public class ResidenceListener1_21 implements Listener {
     private boolean isSlotAir(Animals entity, EquipmentSlot slot) {
         EntityEquipment equipment = entity.getEquipment();
         return equipment != null && equipment.getItem(slot).getType() == Material.AIR;
+    }
+
+    public static void onWindExplode(BlockExplodeEvent event) {
+
+        Block originBlock = event.getBlock();
+
+        if (Residence.getInstance().isDisabledWorldListener(originBlock.getWorld())) {
+            return;
+        }
+        if (Flags.windexplode.isGlobalyEnabled()) {
+            FlagPermissions originPerms = FlagPermissions.getPerms(originBlock.getLocation());
+            // Wind-Explode is prohibited at the origin location; cancel the event directly
+            if (!originPerms.has(Flags.windexplode, originPerms.has(Flags.explode, true))) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+        // Origin allows Wind-Explode, so check each affected block for interaction
+        List<Block> denyInteraction = new ArrayList<>();
+        for (Block block : event.blockList()) {
+            Flags flag = getWindExplodeInteractBlockFlag(block);
+            if (flag == null || !flag.isGlobalyEnabled()) {
+                continue;
+            }
+            FlagPermissions blockPerms = FlagPermissions.getPerms(block.getLocation());
+            if (!blockPerms.has(flag, blockPerms.has(Flags.use, true))) {
+                denyInteraction.add(block);
+            }
+        }
+        if (!denyInteraction.isEmpty()) {
+            event.blockList().removeAll(denyInteraction);
+        }
+    }
+
+    public static void onWindExplode(EntityExplodeEvent event) {
+
+        Entity originEntity = event.getEntity();
+
+        if (Residence.getInstance().isDisabledWorldListener(originEntity.getWorld())) {
+            return;
+        }
+        ProjectileSource cause;
+
+        if (originEntity instanceof AbstractWindCharge) {
+            cause = ((AbstractWindCharge) originEntity).getShooter();
+        } else {
+            // Any entity with Wind-Charged-Effect triggers a Wind-Explode on death
+            cause = ((ProjectileSource) originEntity);
+        }
+        if (Flags.windexplode.isGlobalyEnabled()) {
+            Location originLoc = event.getLocation();
+            FlagPermissions originPerms = FlagPermissions.getPerms(originLoc);
+            // Wind-Explode is prohibited at the origin location; cancel the event directly
+            if (shouldDenyWindExplode(originLoc, cause, originPerms, Flags.windexplode, Flags.explode)) {
+                event.setCancelled(true);
+                return;
+            }
+        }
+        // Origin allows Wind-Explode, so check each affected block for interaction
+        List<Block> denyInteraction = new ArrayList<>();
+        for (Block block : event.blockList()) {
+            Flags flag = getWindExplodeInteractBlockFlag(block);
+            if (flag == null || !flag.isGlobalyEnabled()) {
+                continue;
+            }
+            FlagPermissions blockPerms = FlagPermissions.getPerms(block.getLocation());
+
+            if (shouldDenyWindExplode(block.getLocation(), cause, blockPerms, flag, Flags.use)) {
+                denyInteraction.add(block);
+            }
+        }
+        if (!denyInteraction.isEmpty()) {
+            event.blockList().removeAll(denyInteraction);
+        }
+    }
+
+    private static boolean shouldDenyWindExplode(Location triggerLoc, ProjectileSource cause, FlagPermissions perms,
+                                                 Flags mainFlag, Flags subFlag) {
+        boolean sholudDeny = false;
+        if (cause instanceof Player) {
+            Player player = (Player) cause;
+            if (player.hasMetadata("NPC") || ResAdmin.isResAdmin(player)) {
+                return false;
+            }
+            FlagPermissions playerPerms = FlagPermissions.getPerms(triggerLoc, player);
+            // Because Flags.explode is not FlagMode.Both
+            boolean result = (subFlag == Flags.explode)
+                    ? perms.has(subFlag, true)
+                    : playerPerms.playerHas(player, subFlag, true);
+            if (!playerPerms.playerHas(player, mainFlag, result)) {
+                if (DenyMessageCache.shouldSendDenyMessage(player, mainFlag)) {
+                    lm.Flag_Deny.sendMessage(player, mainFlag);
+                }
+                sholudDeny = true;
+            }
+        } else {
+            if (!perms.has(mainFlag, perms.has(subFlag, true))) {
+                sholudDeny = true;
+            }
+        }
+        return sholudDeny;
+    }
+
+    @Nullable
+    private static Flags getWindExplodeInteractBlockFlag(Block block) {
+        Flags flag = null;
+        CMIMaterial mat = CMIMaterial.get(block.getType());
+        if (mat.containsCriteria(CMIMC.BUTTON)) {
+            flag = Flags.button;
+        } else if (mat.containsCriteria(CMIMC.DOOR) || mat.containsCriteria(CMIMC.FENCEGATE) || mat.containsCriteria(CMIMC.TRAPDOOR)) {
+            flag = Flags.door;
+        } else if (mat == CMIMaterial.BELL || mat.containsCriteria(CMIMC.CANDLE) || mat.containsCriteria(CMIMC.CANDLECAKE)) {
+            flag = Flags.use;
+        } else if (mat == CMIMaterial.LEVER) {
+            flag = Flags.lever;
+        }
+        return flag;
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21.java
@@ -48,6 +48,8 @@ import net.Zrips.CMILib.Items.CMIMC;
 import net.Zrips.CMILib.Items.CMIMaterial;
 import net.Zrips.CMILib.Version.Version;
 
+import static com.bekvon.bukkit.residence.listeners.ResidenceListener1_14.isItemTag;
+
 public class ResidenceListener1_21 implements Listener {
 
     private Residence plugin;
@@ -114,25 +116,6 @@ public class ResidenceListener1_21 implements Listener {
         }
         if (res.getPermissions().playerHas(closest, Flags.leash, FlagCombo.OnlyFalse)) {
             lm.Residence_FlagDeny.sendMessage(closest, Flags.leash, res.getName());
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
-    public void onAnimalEnterVehicle(VehicleEnterEvent event) {
-
-        Entity entity = event.getEntered();
-
-        if (FlagPermissions.shouldIgnoreCheck(Flags.boarding, entity)) {
-            return;
-        }
-        if (!(entity instanceof LivingEntity))
-            return;
-
-        if (!Utils.isAnimal(entity))
-            return;
-
-        if (FlagPermissions.getPerms(entity.getLocation()).has(Flags.boarding, FlagCombo.OnlyFalse)) {
             event.setCancelled(true);
         }
     }
@@ -337,10 +320,6 @@ public class ResidenceListener1_21 implements Listener {
         default:
             return false;
         }
-    }
-
-    private boolean isItemTag(Material item, String tagName) {
-        return ResidenceListener1_14.isItemTag(item, tagName);
     }
 
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_8_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_8_Paper.java
@@ -13,7 +13,6 @@ import org.bukkit.inventory.EquipmentSlot;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
@@ -86,17 +85,8 @@ public class ResidenceListener1_21_8_Paper implements Listener {
             return false;
         }
         if (pushedBy != null) {
-            if (pushedBy.hasMetadata("NPC") || ResAdmin.isResAdmin(pushedBy)) {
-                return false;
-            }
-            FlagPermissions perms = FlagPermissions.getPerms(target.getLocation(), pushedBy);
-            boolean result = (subFlag == null || perms.playerHas(pushedBy, subFlag, true));
 
-            if (!perms.playerHas(pushedBy, mainFlag, result)) {
-                lm.Flag_Deny.sendMessage(pushedBy, mainFlag);
-                return true;
-            }
-            return false;
+            return FlagPermissions.shouldDenyAndNotify(pushedBy, target, mainFlag, subFlag);
 
         } else {
             FlagPermissions perms = FlagPermissions.getPerms(target.getLocation());

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_8_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_8_Paper.java
@@ -15,7 +15,6 @@ import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.containers.lm;
-import com.bekvon.bukkit.residence.listenersCache.DenyMessageCache;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.protection.FlagPermissions.FlagCombo;
 import com.bekvon.bukkit.residence.utils.Utils;
@@ -56,9 +55,7 @@ public class ResidenceListener1_21_8_Paper implements Listener {
             // Monster-on-player knockback doesn't need to check Flags.pvp
             // Allow players to knock themselves back (e.g., by Wind Charges)
             if (player != null && !target.equals(player) && FlagPermissions.has(target.getLocation(), Flags.pvp, FlagCombo.OnlyFalse)) {
-                if (DenyMessageCache.shouldSendDenyMessage(player, Flags.pvp)) {
-                    lm.Flag_Deny.sendMessage(player, Flags.pvp);
-                }
+                lm.Flag_Deny.sendMessage(player, Flags.pvp);
                 return true;
             }
             return false;
@@ -96,9 +93,7 @@ public class ResidenceListener1_21_8_Paper implements Listener {
             boolean result = (subFlag == null || perms.playerHas(pushedBy, subFlag, true));
 
             if (!perms.playerHas(pushedBy, mainFlag, result)) {
-                if (DenyMessageCache.shouldSendDenyMessage(pushedBy, mainFlag)) {
-                    lm.Flag_Deny.sendMessage(pushedBy, mainFlag);
-                }
+                lm.Flag_Deny.sendMessage(pushedBy, mainFlag);
                 return true;
             }
             return false;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_8_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_8_Paper.java
@@ -34,7 +34,7 @@ public class ResidenceListener1_21_8_Paper implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onKnockback(EntityPushedByEntityAttackEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld())) {
+        if (plugin.isDisabledWorldListener(event.getEntity())) {
             return;
         }
         if (shouldCancelKnockBack(event.getEntity(), event.getPushedBy()))

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_8_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_8_Paper.java
@@ -47,15 +47,21 @@ public class ResidenceListener1_21_8_Paper implements Listener {
         Player player = Utils.potentialProjectileToPlayer(pushedBy);
 
         if (target instanceof ArmorStand) {
-            return shouldDeny(target, player, Flags.destroy);
+            return shouldDeny(target, player, Flags.destroy, null);
         }
         if (target instanceof Boat || target instanceof Minecart) {
-            return shouldDeny(target, player, Flags.vehicledestroy);
+            return shouldDeny(target, player, Flags.vehicledestroy, null);
         }
         if (target instanceof Player) {
             // Monster-on-player knockback doesn't need to check Flags.pvp
             // Allow players to knock themselves back (e.g., by Wind Charges)
-            return player != null && !target.equals(player) && FlagPermissions.has(target.getLocation(), Flags.pvp, FlagCombo.OnlyFalse);
+            if (player != null && !target.equals(player) && FlagPermissions.has(target.getLocation(), Flags.pvp, FlagCombo.OnlyFalse)) {
+                if (DenyMessageCache.shouldSendDenyMessage(player, Flags.pvp)) {
+                    lm.Flag_Deny.sendMessage(player, Flags.pvp);
+                }
+                return true;
+            }
+            return false;
         }
         if (Utils.isAnimal(target)) {
             // SulfurCube containing blocks doesn't take damage
@@ -66,38 +72,32 @@ public class ResidenceListener1_21_8_Paper implements Listener {
                 EntityEquipment equipment = ((org.bukkit.entity.SulfurCube) target).getEquipment();
                 // Check if SulfurCube has a block inside
                 if (equipment != null && !equipment.getItem(EquipmentSlot.BODY).isEmpty()) {
-                    return shouldDenyPush(target, player);
+                    return shouldDeny(target, player, Flags.push, Flags.animalkilling);
                 }
                 // SulfurCube without blocks still checks Flags.animalkilling
             }
-            return shouldDeny(target, player, Flags.animalkilling);
+            return shouldDeny(target, player, Flags.animalkilling, null);
         }
         if (ResidenceEntityListener.isMonster(target)) {
-            return shouldDeny(target, player, Flags.mobkilling);
+            return shouldDeny(target, player, Flags.mobkilling, null);
         }
         return false;
     }
 
-    private static boolean shouldDeny(Entity target, Player pushedBy, Flags flag) {
-        if (pushedBy != null) {
-            if (pushedBy.hasMetadata("NPC") || ResAdmin.isResAdmin(pushedBy)) {
-                return false;
-            }
-            return FlagPermissions.has(target.getLocation(), pushedBy, flag, FlagCombo.OnlyFalse);
-        } else {
-            return FlagPermissions.has(target.getLocation(), flag, FlagCombo.OnlyFalse);
+    private static boolean shouldDeny(Entity target, Player pushedBy, Flags mainFlag, Flags subFlag) {
+        if (!mainFlag.isGlobalyEnabled()) {
+            return false;
         }
-    }
-
-    private static boolean shouldDenyPush(Entity target, Player pushedBy) {
         if (pushedBy != null) {
             if (pushedBy.hasMetadata("NPC") || ResAdmin.isResAdmin(pushedBy)) {
                 return false;
             }
             FlagPermissions perms = FlagPermissions.getPerms(target.getLocation(), pushedBy);
-            if (!perms.playerHas(pushedBy, Flags.push, perms.playerHas(pushedBy, Flags.animalkilling, true))) {
-                if (DenyMessageCache.shouldSendDenyMessage(pushedBy, Flags.push)) {
-                    lm.Flag_Deny.sendMessage(pushedBy, Flags.push);
+            boolean result = (subFlag == null || perms.playerHas(pushedBy, subFlag, true));
+
+            if (!perms.playerHas(pushedBy, mainFlag, result)) {
+                if (DenyMessageCache.shouldSendDenyMessage(pushedBy, mainFlag)) {
+                    lm.Flag_Deny.sendMessage(pushedBy, mainFlag);
                 }
                 return true;
             }
@@ -105,7 +105,9 @@ public class ResidenceListener1_21_8_Paper implements Listener {
 
         } else {
             FlagPermissions perms = FlagPermissions.getPerms(target.getLocation());
-            return !perms.has(Flags.push, perms.has(Flags.animalkilling, true));
+            boolean result = (subFlag == null || perms.has(subFlag, true));
+
+            return !perms.has(mainFlag, result);
         }
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_8_Spigot.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_8_Spigot.java
@@ -1,6 +1,7 @@
 package com.bekvon.bukkit.residence.listeners;
 
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityKnockbackByEntityEvent;
 
@@ -14,8 +15,12 @@ public class ResidenceListener1_21_8_Spigot implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onKnockback(EntityKnockbackByEntityEvent event) {
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(event.getEntity())) {
+            return;
+        }
         if (ResidenceListener1_21_8_Paper.shouldCancelKnockBack(event.getEntity(), event.getSourceEntity()))
             event.setCancelled(true);
     }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_9_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener1_21_9_Paper.java
@@ -29,14 +29,10 @@ public class ResidenceListener1_21_9_Paper implements Listener {
 
         if (!event.isAllowed())
             return;
-        // Disabling listener if flag disabled globally
-        if (!Flags.golemopenchest.isGlobalyEnabled())
-            return;
 
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
+        if (FlagPermissions.shouldIgnoreCheck(Flags.golemopenchest, event.getEntity())) {
             return;
-
+        }
         if (event.getEntityType() != EntityType.COPPER_GOLEM)
             return;
 
@@ -51,15 +47,12 @@ public class ResidenceListener1_21_9_Paper implements Listener {
     // Prevent external copper golems from forming statues inside Residence
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onCopperGolemStatueForm(EntityChangeBlockEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.build.isGlobalyEnabled())
-            return;
 
         Block block = event.getBlock();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.build, block)) {
+            return;
+        }
         if (event.getEntityType() != EntityType.COPPER_GOLEM)
             return;
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener26_2.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener26_2.java
@@ -17,9 +17,7 @@ import org.bukkit.inventory.EquipmentSlot;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
-import com.bekvon.bukkit.residence.containers.lm;
 
 public class ResidenceListener26_2 implements Listener {
 
@@ -31,13 +29,10 @@ public class ResidenceListener26_2 implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerIgniteTntSulfurCube(PlayerInteractEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.ignite.isGlobalyEnabled()) {
-            return;
-        }
+
         Entity entity = event.getRightClicked();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld())) {
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.ignite, entity)) {
             return;
         }
         if (!(entity instanceof SulfurCube)) {
@@ -53,34 +48,24 @@ public class ResidenceListener26_2 implements Listener {
             return;
         }
         Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player)) {
-            return;
-        }
-        FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation(), player);
-        if (perms.playerHas(player, Flags.ignite, perms.playerHas(player, Flags.animalkilling, true))) {
-            return;
-        }
-        lm.Flag_Deny.sendMessage(player, Flags.ignite);
-        event.setCancelled(true);
 
+        if (FlagPermissions.shouldDenyAndNotify(player, entity, Flags.ignite, Flags.animalkilling)) {
+            event.setCancelled(true);
+        }
     }
 
     // fix https://github.com/PaperMC/Paper/issues/14149
     @EventHandler(priority = EventPriority.LOWEST) // Do not use (ignoreCancelled = true)
     public void onPlayerSulfurCubeBucketEmpty(PlayerInteractEvent event) {
+
         if (event.useItemInHand() == Result.DENY) {
-            return;
-        }
-        // Disabling listener if flag disabled globally
-        if (!Flags.build.isGlobalyEnabled()) {
             return;
         }
         Block block= event.getClickedBlock();
         if (block == null) {
             return;
         }
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld())) {
+        if (FlagPermissions.shouldIgnoreCheck(Flags.build, block)) {
             return;
         }
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
@@ -90,15 +75,9 @@ public class ResidenceListener26_2 implements Listener {
             return;
         }
         Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player)) {
-            return;
-        }
-        if (FlagPermissions.has(block.getRelative(event.getBlockFace()).getLocation(),  player, Flags.build, true)) {
-            return;
-        }
 
-        lm.Flag_Deny.sendMessage(player, Flags.build);
-        event.setCancelled(true);
-
+        if (FlagPermissions.shouldDenyAndNotify(player, block.getRelative(event.getBlockFace()), Flags.build, null)) {
+            event.setCancelled(true);
+        }
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener26_2.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener26_2.java
@@ -1,13 +1,17 @@
 package com.bekvon.bukkit.residence.listeners;
 
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.SulfurCube;
+import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.EquipmentSlot;
 
@@ -57,6 +61,43 @@ public class ResidenceListener26_2 implements Listener {
             return;
         }
         lm.Flag_Deny.sendMessage(player, Flags.ignite);
+        event.setCancelled(true);
+
+    }
+
+    // fix https://github.com/PaperMC/Paper/issues/14149
+    @EventHandler(priority = EventPriority.LOWEST) // Do not use (ignoreCancelled = true)
+    public void onPlayerSulfurCubeBucketEmpty(PlayerInteractEvent event) {
+        if (event.useItemInHand() == Result.DENY) {
+            return;
+        }
+        // Disabling listener if flag disabled globally
+        if (!Flags.build.isGlobalyEnabled()) {
+            return;
+        }
+        Block block= event.getClickedBlock();
+        if (block == null) {
+            return;
+        }
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(block.getWorld())) {
+            return;
+        }
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        if (event.getItem() == null || event.getItem().getType() != Material.SULFUR_CUBE_BUCKET) {
+            return;
+        }
+        Player player = event.getPlayer();
+        if (ResAdmin.isResAdmin(player)) {
+            return;
+        }
+        if (FlagPermissions.has(block.getRelative(event.getBlockFace()).getLocation(),  player, Flags.build, true)) {
+            return;
+        }
+
+        lm.Flag_Deny.sendMessage(player, Flags.build);
         event.setCancelled(true);
 
     }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener26_2_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener26_2_Paper.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.listenersCache.PlayerCollideWithEntityCache;
+import com.bekvon.bukkit.residence.listenersCache.PlayerCollideWithEntityCache.PlayerCollideWithEntityKey;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.utils.Utils;
 
@@ -59,27 +60,26 @@ public class ResidenceListener26_2_Paper implements Listener {
             // Only handle entity pushes involving a player
             return;
         }
-        PlayerCollideWithEntityCache.PlayerCollideWithEntityKey key
-                = new PlayerCollideWithEntityCache.PlayerCollideWithEntityKey(target, pushedBy);
-
+        PlayerCollideWithEntityKey key = new PlayerCollideWithEntityKey(target, pushedBy);
+        // Collisions are high-frequency events; caching is more lightweight
         if (PlayerCollideWithEntityCache.getOrCompute(key, () -> shouldDenyPush(target, pushedBy))) {
             event.setCancelled(true);
         }
     }
 
     private boolean shouldDenyPush(@NotNull Entity target, @NotNull Player pushedBy) {
-        Flags subFlags = null;
+        Flags subFlag = null;
 
         if (target instanceof Boat || target instanceof Minecart) {
-            subFlags = Flags.vehicledestroy;
+            subFlag = Flags.vehicledestroy;
 
         } else if (Utils.isAnimal(target)) {
-            subFlags = Flags.animalkilling;
+            subFlag = Flags.animalkilling;
 
         } else if (ResidenceEntityListener.isMonster(target)) {
-            subFlags = Flags.mobkilling;
+            subFlag = Flags.mobkilling;
 
         }
-        return FlagPermissions.shouldDenyAndNotify(pushedBy, target, Flags.push, subFlags);
+        return FlagPermissions.shouldDenyAndNotify(pushedBy, target, Flags.push, subFlag);
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener26_2_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener26_2_Paper.java
@@ -32,18 +32,14 @@ public class ResidenceListener26_2_Paper implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerCollideWithEntity(EntityCollideWithEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.push.isGlobalyEnabled()) {
-            return;
-        }
         // Get the two entities involved in the collision
         List<Entity> entities = event.getEntities();
         if (entities.size() < 2) {
             return;
         }
         Entity entity1 = entities.get(0);
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(entity1.getWorld())) {
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.push, entity1)) {
             return;
         }
         Entity entity2 = entities.get(1);

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener26_2_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener26_2_Paper.java
@@ -15,7 +15,6 @@ import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.containers.lm;
-import com.bekvon.bukkit.residence.listenersCache.DenyMessageCache;
 import com.bekvon.bukkit.residence.listenersCache.PlayerCollideWithEntityCache;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.utils.Utils;
@@ -88,9 +87,7 @@ public class ResidenceListener26_2_Paper implements Listener {
 
         }
         if (!perms.playerHas(pushedBy, Flags.push, fallback)) {
-            if (DenyMessageCache.shouldSendDenyMessage(pushedBy, Flags.push)) {
-                lm.Flag_Deny.sendMessage(pushedBy, Flags.push);
-            }
+            lm.Flag_Deny.sendMessage(pushedBy, Flags.push);
             return true;
         }
         return false;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener26_2_Paper.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidenceListener26_2_Paper.java
@@ -13,8 +13,6 @@ import org.jetbrains.annotations.NotNull;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
-import com.bekvon.bukkit.residence.containers.ResAdmin;
-import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.listenersCache.PlayerCollideWithEntityCache;
 import com.bekvon.bukkit.residence.protection.FlagPermissions;
 import com.bekvon.bukkit.residence.utils.Utils;
@@ -46,6 +44,10 @@ public class ResidenceListener26_2_Paper implements Listener {
         Player pushedBy;
 
         if (entity1 instanceof Player) {
+            // Does not apply to player-player collisions; they are handled client-side
+            if (entity2 instanceof Player) {
+                return;
+            }
             pushedBy = (Player) entity1;
             target = entity2;
 
@@ -66,30 +68,18 @@ public class ResidenceListener26_2_Paper implements Listener {
     }
 
     private boolean shouldDenyPush(@NotNull Entity target, @NotNull Player pushedBy) {
-        // Does not apply to player-player collisions; they are handled client-side
-        if (target instanceof Player) {
-            return false;
-        }
-        if (pushedBy.hasMetadata("NPC") || ResAdmin.isResAdmin(pushedBy)) {
-            return false;
-        }
-        FlagPermissions perms = FlagPermissions.getPerms(target.getLocation(), pushedBy);
-        boolean fallback = true;
+        Flags subFlags = null;
 
         if (target instanceof Boat || target instanceof Minecart) {
-            fallback = perms.playerHas(pushedBy, Flags.vehicledestroy, true);
+            subFlags = Flags.vehicledestroy;
 
         } else if (Utils.isAnimal(target)) {
-            fallback = perms.playerHas(pushedBy, Flags.animalkilling, true);
+            subFlags = Flags.animalkilling;
 
         } else if (ResidenceEntityListener.isMonster(target)) {
-            fallback = perms.playerHas(pushedBy, Flags.mobkilling, true);
+            subFlags = Flags.mobkilling;
 
         }
-        if (!perms.playerHas(pushedBy, Flags.push, fallback)) {
-            lm.Flag_Deny.sendMessage(pushedBy, Flags.push);
-            return true;
-        }
-        return false;
+        return FlagPermissions.shouldDenyAndNotify(pushedBy, target, Flags.push, subFlags);
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -1545,7 +1545,7 @@ public class ResidencePlayerListener implements Listener {
             return;
         }
         Player player = event.getPlayer();
-        Flags mainFlag = null;
+        Flags mainFlag;
         Flags subFlag = null;
 
         if (Flags.commandblock.isGlobalyEnabled() && entity instanceof CommandMinecart) {
@@ -1564,6 +1564,8 @@ public class ResidencePlayerListener implements Listener {
         } else if (Flags.trade.isGlobalyEnabled() && isTrader(entity)) {
             mainFlag = Flags.trade;
 
+        } else {
+            return;
         }
         if (FlagPermissions.shouldDenyAndNotify(player, entity, mainFlag, subFlag)) {
             event.setCancelled(true);
@@ -1589,7 +1591,7 @@ public class ResidencePlayerListener implements Listener {
             return;
         }
         CMIMaterial held = CMIMaterial.get(item);
-        Flags mainFlag = null;
+        Flags mainFlag;
         Flags subFlag = null;
 
         if (entity instanceof ItemFrame) {
@@ -1598,8 +1600,8 @@ public class ResidencePlayerListener implements Listener {
             if (!plugin.getItemManager().isAllowed(item.getType(), group, entity.getWorld().getName()) && !ResAdmin.isResAdmin(player)) {
                 lm.General_ItemBlacklisted.sendMessage(player);
                 event.setCancelled(true);
-                return;
             }
+            return;
 
         } else if (Flags.dye.isGlobalyEnabled() && entity.getType() == EntityType.SHEEP && held.containsCriteria(CMIMC.DYE)) {
             mainFlag = Flags.dye;
@@ -1613,6 +1615,8 @@ public class ResidencePlayerListener implements Listener {
                 subFlag = Flags.mobkilling;
             }
 
+        } else {
+            return;
         }
         if (FlagPermissions.shouldDenyAndNotify(player, entity, mainFlag, subFlag)) {
             event.setCancelled(true);

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -62,8 +62,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.util.Vector;
-import org.jetbrains.annotations.NotNull;
 
 import com.bekvon.bukkit.residence.ConfigManager;
 import com.bekvon.bukkit.residence.Residence;
@@ -346,15 +344,15 @@ public class ResidencePlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onFishingRodUse(PlayerFishEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.hook.isGlobalyEnabled())
-            return;
+
         if (event == null)
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
-            return;
+
         Player player = event.getPlayer();
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.hook, player)) {
+            return;
+        }
         if (event.getCaught() == null)
             return;
         if ((Utils.isArmorStandEntity(event.getCaught().getType()) || event.getCaught() instanceof Boat || event.getCaught() instanceof LivingEntity) && !ResAdmin.isResAdmin(player)) {
@@ -643,14 +641,12 @@ public class ResidencePlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onCommand(PlayerCommandPreprocessEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.command.isGlobalyEnabled())
-            return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
-            return;
+
         Player player = event.getPlayer();
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.command, player)) {
+            return;
+        }
         FlagPermissions perms = FlagPermissions.getPerms(player.getLocation(), player);
 
         FlagPermissions globalPerm = plugin.getWorldFlags().getPerms(player);
@@ -1067,17 +1063,14 @@ public class ResidencePlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerBuildWithSpecificItems(PlayerInteractEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.build.isGlobalyEnabled())
-            return;
 
         Block block = event.getClickedBlock();
         if (block == null)
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.build, block)) {
+            return;
+        }
         Location loc = null;
 
         switch (event.getAction()) {
@@ -1108,16 +1101,10 @@ public class ResidencePlayerListener implements Listener {
             return;
 
         Player player = event.getPlayer();
-        if (player.hasMetadata("NPC") || ResAdmin.isResAdmin(player))
-            return;
 
-        FlagPermissions perms = FlagPermissions.getPerms(loc, player);
-        if (perms.playerHas(player, Flags.place, perms.playerHas(player, Flags.build, true)))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.build);
-        event.setCancelled(true);
-
+        if (FlagPermissions.shouldDenyAndNotify(player, loc, Flags.place, Flags.build)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -1578,23 +1565,9 @@ public class ResidencePlayerListener implements Listener {
             mainFlag = Flags.trade;
 
         }
-        if (shouldDenyPlayerInteractEntity(player, entity, mainFlag, subFlag)) {
+        if (FlagPermissions.shouldDenyAndNotify(player, entity, mainFlag, subFlag)) {
             event.setCancelled(true);
         }
-    }
-
-    private boolean shouldDenyPlayerInteractEntity(@NotNull Player player, @NotNull Entity entity, Flags mainFlag, Flags subFlag) {
-        if (mainFlag == null) {
-            return false;
-        }
-        FlagPermissions perms = FlagPermissions.getPerms(entity.getLocation(), player);
-        boolean result = (subFlag == null || perms.playerHas(player, subFlag, true));
-        // if mainFlag is in None state -> use subFlag result
-        if (perms.playerHas(player, mainFlag, result) || ResAdmin.isResAdmin(player)) {
-            return false;
-        }
-        lm.Flag_Deny.sendMessage(player, mainFlag);
-        return true;
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
@@ -1641,7 +1614,7 @@ public class ResidencePlayerListener implements Listener {
             }
 
         }
-        if (shouldDenyPlayerInteractEntity(player, entity, mainFlag, subFlag)) {
+        if (FlagPermissions.shouldDenyAndNotify(player, entity, mainFlag, subFlag)) {
             event.setCancelled(true);
         }
     }
@@ -1674,38 +1647,23 @@ public class ResidencePlayerListener implements Listener {
             return;
 
         Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player))
-            return;
 
-        FlagPermissions perms = FlagPermissions.getPerms(loc, player);
-        if (perms.playerHas(player, Flags.vehicleplacing, perms.playerHas(player, Flags.build, true)))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.vehicleplacing);
-        event.setCancelled(true);
-
+        if (FlagPermissions.shouldDenyAndNotify(player, loc, Flags.vehicleplacing, Flags.build)) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerShearEntity(PlayerShearEntityEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.shear.isGlobalyEnabled())
-            return;
 
         Player player = event.getPlayer();
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(player.getWorld()))
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.shear, player)) {
             return;
-
-        if (ResAdmin.isResAdmin(player))
-            return;
-
-        if (FlagPermissions.has(event.getEntity().getLocation(), player, Flags.shear, true))
-            return;
-
-        lm.Flag_Deny.sendMessage(player, Flags.shear);
-        event.setCancelled(true);
-
+        }
+        if (FlagPermissions.shouldDenyAndNotify(player, event.getEntity(), Flags.shear, null)) {
+            event.setCancelled(true);
+        }
     }
 
     private boolean isCauldron(Block block) {

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -208,7 +208,7 @@ public class ResidencePlayerListener implements Listener {
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPlayerGlobalChat(AsyncPlayerChatEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         if (!plugin.getConfigManager().isGlobalChatEnabled())
             return;
@@ -259,7 +259,7 @@ public class ResidencePlayerListener implements Listener {
 
     private void procEvent(AsyncPlayerChatEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         if (!plugin.getConfigManager().isGlobalChatEnabled())
             return;
@@ -703,7 +703,7 @@ public class ResidencePlayerListener implements Listener {
         if (event.getPlayer() == null)
             return;
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
 
         Block block = event.getClickedBlock();
@@ -752,7 +752,7 @@ public class ResidencePlayerListener implements Listener {
     public void onSignCreate(SignChangeEvent event) {
 
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         Block block = event.getBlock();
 
@@ -814,7 +814,7 @@ public class ResidencePlayerListener implements Listener {
     public void onSignDestroy(BlockBreakEvent event) {
 
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         if (event.isCancelled())
             return;
@@ -934,7 +934,7 @@ public class ResidencePlayerListener implements Listener {
     public void onPlayerSpawn(PlayerRespawnEvent event) {
 
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getRespawnLocation().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getRespawnLocation()))
             return;
         Location loc = event.getRespawnLocation();
         Boolean bed = event.isBedSpawn();
@@ -1118,7 +1118,7 @@ public class ResidencePlayerListener implements Listener {
             return;
         }
         // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld())) {
+        if (plugin.isDisabledWorldListener(block)) {
             return;
         }
         CMIMaterial mat = CMIMaterial.get(block.getType());
@@ -1188,7 +1188,7 @@ public class ResidencePlayerListener implements Listener {
         if (block == null)
             return;
         // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
+        if (plugin.isDisabledWorldListener(block))
             return;
         if (event.getAction() != Action.LEFT_CLICK_BLOCK && event.getAction() != Action.RIGHT_CLICK_BLOCK)
             return;
@@ -1244,7 +1244,7 @@ public class ResidencePlayerListener implements Listener {
         if (block == null)
             return;
         // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
+        if (plugin.isDisabledWorldListener(block))
             return;
         if (event.getAction() != Action.LEFT_CLICK_BLOCK)
             return;
@@ -1367,7 +1367,7 @@ public class ResidencePlayerListener implements Listener {
         if (block == null)
             return;
         // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
+        if (plugin.isDisabledWorldListener(block))
             return;
 
         if (event.getAction() != Action.LEFT_CLICK_BLOCK && event.getAction() != Action.RIGHT_CLICK_BLOCK)
@@ -1541,7 +1541,7 @@ public class ResidencePlayerListener implements Listener {
     public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
         Entity entity = event.getRightClicked();
         // disabling event on world
-        if (plugin.isDisabledWorldListener(entity.getWorld())) {
+        if (plugin.isDisabledWorldListener(entity)) {
             return;
         }
         Player player = event.getPlayer();
@@ -1573,8 +1573,8 @@ public class ResidencePlayerListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerInteractEntityWithItem(PlayerInteractEntityEvent event) {
         Entity entity = event.getRightClicked();
-        World world = entity.getWorld();
-        if (plugin.isDisabledWorldListener(world)) {
+
+        if (plugin.isDisabledWorldListener(entity)) {
             return;
         }
         Player player = event.getPlayer();
@@ -1595,7 +1595,7 @@ public class ResidencePlayerListener implements Listener {
         if (entity instanceof ItemFrame) {
             // Check held Material Blacklist
             PermissionGroup group = plugin.getPlayerManager().getResidencePlayer(player).getGroup();
-            if (!plugin.getItemManager().isAllowed(item.getType(), group, world.getName()) && !ResAdmin.isResAdmin(player)) {
+            if (!plugin.getItemManager().isAllowed(item.getType(), group, entity.getWorld().getName()) && !ResAdmin.isResAdmin(player)) {
                 lm.General_ItemBlacklisted.sendMessage(player);
                 event.setCancelled(true);
                 return;
@@ -1683,7 +1683,7 @@ public class ResidencePlayerListener implements Listener {
     public void onPlayerBucketEmpty(PlayerBucketEmptyEvent event) {
         // disabling event on world
 
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         Player player = event.getPlayer();
         if (ResAdmin.isResAdmin(player))
@@ -1754,7 +1754,7 @@ public class ResidencePlayerListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerBucketFill(PlayerBucketFillEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         Player player = event.getPlayer();
         if (ResAdmin.isResAdmin(player))
@@ -1784,7 +1784,7 @@ public class ResidencePlayerListener implements Listener {
     public void onPlayerTeleport(PlayerTeleportEvent event) {
 
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         Player player = event.getPlayer();
 
@@ -1842,7 +1842,7 @@ public class ResidencePlayerListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerDeath(final PlayerDeathEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getEntity().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getEntity()))
             return;
         Player player = event.getEntity();
         if (player == null)
@@ -2112,7 +2112,7 @@ public class ResidencePlayerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerMove(PlayerMoveEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         Player player = event.getPlayer();
         if (player == null)
@@ -2154,7 +2154,7 @@ public class ResidencePlayerListener implements Listener {
     public void onPlayerMoveInVehicle(VehicleMoveEvent event) {
 
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getVehicle().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getVehicle()))
             return;
 
         List<Entity> ent = Utils.getPassengers(event.getVehicle());
@@ -2666,7 +2666,7 @@ public class ResidencePlayerListener implements Listener {
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerChat(AsyncPlayerChatEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         String pname = event.getPlayer().getName();
         if (!plugin.getConfigManager().chatEnabled() || playerPersistentData.get(event.getPlayer()).isChatEnabled())

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -21,10 +21,11 @@ import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Boat;
 import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemFrame;
+import org.bukkit.entity.LeashHitch;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Sheep;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.entity.minecart.CommandMinecart;
 import org.bukkit.event.Event.Result;
@@ -355,7 +356,7 @@ public class ResidencePlayerListener implements Listener {
         }
         if (event.getCaught() == null)
             return;
-        if ((Utils.isArmorStandEntity(event.getCaught().getType()) || event.getCaught() instanceof Boat || event.getCaught() instanceof LivingEntity) && !ResAdmin.isResAdmin(player)) {
+        if ((Utils.isArmorStand(event.getCaught()) || event.getCaught() instanceof Boat || event.getCaught() instanceof LivingEntity) && !ResAdmin.isResAdmin(player)) {
             FlagPermissions perm = FlagPermissions.getPerms(event.getCaught().getLocation());
             ClaimedResidence res = ClaimedResidence.getByLoc(event.getCaught().getLocation());
             if (perm.has(Flags.hook, FlagCombo.OnlyFalse)) {
@@ -1532,11 +1533,6 @@ public class ResidencePlayerListener implements Listener {
         return false;
     }
 
-    private boolean isTrader(Entity entity) {
-        CMIEntityType type = CMIEntityType.get(entity);
-        return type == CMIEntityType.VILLAGER || type == CMIEntityType.WANDERING_TRADER;
-    }
-
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
         Entity entity = event.getRightClicked();
@@ -1555,13 +1551,16 @@ public class ResidencePlayerListener implements Listener {
             mainFlag = Flags.container;
             subFlag = Flags.use;
 
+        } else if (Flags.leash.isGlobalyEnabled() && entity instanceof LeashHitch) {
+            mainFlag = Flags.leash;
+
         } else if (Flags.container.isGlobalyEnabled() && canHaveContainer(entity, player)) {
             mainFlag = Flags.container;
 
         } else if (Flags.riding.isGlobalyEnabled() && canRide(entity, player)) {
             mainFlag = Flags.riding;
 
-        } else if (Flags.trade.isGlobalyEnabled() && isTrader(entity)) {
+        } else if (Flags.trade.isGlobalyEnabled() && Utils.isVillagerOrTrader(entity)) {
             mainFlag = Flags.trade;
 
         } else {
@@ -1603,7 +1602,7 @@ public class ResidencePlayerListener implements Listener {
             }
             return;
 
-        } else if (Flags.dye.isGlobalyEnabled() && entity.getType() == EntityType.SHEEP && held.containsCriteria(CMIMC.DYE)) {
+        } else if (Flags.dye.isGlobalyEnabled() && entity instanceof Sheep && held.containsCriteria(CMIMC.DYE)) {
             mainFlag = Flags.dye;
             subFlag = Flags.animalkilling;
 

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -1621,17 +1621,14 @@ public class ResidencePlayerListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerPlaceVehicle(PlayerInteractEvent event) {
-        // Disabling listener if flag disabled globally
-        if (!Flags.vehicleplacing.isGlobalyEnabled())
-            return;
 
         Block block = event.getClickedBlock();
         if (block == null)
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block.getWorld()))
-            return;
 
+        if (FlagPermissions.shouldIgnoreCheck(Flags.vehicleplacing, block)) {
+            return;
+        }
         Location loc = null;
 
         CMIMaterial heldItem = CMIMaterial.get(event.getItem());

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -1632,7 +1632,7 @@ public class ResidencePlayerListener implements Listener {
             mainFlag = Flags.dye;
             subFlag = Flags.animalkilling;
 
-        } else if (Flags.nametag.isGlobalyEnabled() && held == CMIMaterial.NAME_TAG) {
+        } else if (Flags.nametag.isGlobalyEnabled() && entity instanceof LivingEntity && held == CMIMaterial.NAME_TAG) {
             mainFlag = Flags.nametag;
             if (Utils.isAnimal(entity)) {
                 subFlag = Flags.animalkilling;

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -17,11 +17,9 @@ import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
-import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Boat;
 import org.bukkit.entity.Damageable;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.LeashHitch;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -37,6 +35,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.block.SignChangeEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
 import org.bukkit.event.player.PlayerBucketFillEvent;
@@ -57,8 +56,10 @@ import org.bukkit.event.player.PlayerShearEntityEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.event.player.PlayerToggleFlightEvent;
+import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.event.vehicle.VehicleMoveEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
@@ -1300,35 +1301,33 @@ public class ResidencePlayerListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.LOWEST) // Do not use (ignoreCancelled = true)
-    public void onPlayerInteract(PlayerInteractEvent event) {
-
-        Block block = event.getClickedBlock();
-        if (block == null)
+    public void onPlayerClickInteract(PlayerInteractEvent event) {
+        if (event.getAction() == Action.PHYSICAL) {
             return;
-        // disabling event on world
-        if (plugin.isDisabledWorldListener(block))
-            return;
-
-        if (event.getAction() != Action.LEFT_CLICK_BLOCK && event.getAction() != Action.RIGHT_CLICK_BLOCK)
-            return;
-
+        }
         Player player = event.getPlayer();
-        if (ResAdmin.isResAdmin(player))
+        // disabling event on world
+        if (plugin.isDisabledWorldListener(player)) {
             return;
-
-        if (event.useItemInHand() != Result.DENY) {
-            CMIMaterial heldItem = CMIMaterial.get(event.getItem());
-            // Check held Material Blacklist
-            if (!heldItem.isNone() && heldItem.isValidItem() && !plugin.getItemManager().isAllowed(
-                    heldItem.getMaterial(),
-                    plugin.getPlayerManager().getResidencePlayer(player).getGroup(),
-                    player.getWorld().getName())) {
-                lm.General_ItemBlacklisted.sendMessage(player);
-                event.setCancelled(true);
-                return;
-            }
+        }
+        if (ResAdmin.isResAdmin(player)) {
+            return;
+        }
+        // Check held Material Blacklist
+        if (event.useItemInHand() != Result.DENY && event.getItem() != null
+                && !plugin.getItemManager().isAllowed(event.getItem().getType(), player)) {
+            lm.General_ItemBlacklisted.sendMessage(player);
+            event.setCancelled(true);
+            return;
+        }
+        if (event.getAction() != Action.LEFT_CLICK_BLOCK && event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
         }
         if (event.useInteractedBlock() == Result.DENY) {
+            return;
+        }
+        Block block = event.getClickedBlock();
+        if (block == null) {
             return;
         }
         Material blockType = block.getType();
@@ -1401,57 +1400,6 @@ public class ResidencePlayerListener implements Listener {
         // End AbstractBlockClickFlag Check
     }
 
-    private boolean canHaveContainer(Entity entity, Player player) {
-        CMIEntityType type = CMIEntityType.get(entity);
-        if (type != null) {
-            // Click to open container entities
-            switch (type) {
-            case ALLAY:
-            case CHEST_MINECART:
-            case FURNACE_MINECART:
-            case HOPPER_MINECART:
-                return true;
-            default:
-                break;
-            }
-        }
-        // Click requires sneaking to open these entity containers
-        // Avoid overriding Flags.riding
-        if (player.isSneaking()) {
-            if (Version.isCurrentEqualOrHigher(Version.v1_19_0)) {
-                return ResidenceListener1_19.canHaveContainer1_19(entity);
-            }
-            return entity instanceof AbstractHorse;
-        }
-        return false;
-    }
-
-    private boolean canRide(Entity entity, Player player) {
-        // Cannot ride while sneaking
-        if (player.isSneaking()) {
-            return false;
-        }
-        if (entity instanceof Vehicle) {
-            CMIEntityType type = CMIEntityType.get(entity);
-            if (type == null) {
-                return true;
-            }
-            switch (type) {
-            // Non-rideable Vehicles
-            case CHEST_MINECART:
-            case COMMAND_BLOCK_MINECART:
-            case FURNACE_MINECART:
-            case HOPPER_MINECART:
-            case SPAWNER_MINECART:
-            case TNT_MINECART:
-                return false;
-            default:
-                return true;
-            }
-        }
-        return false;
-    }
-
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
         Entity entity = event.getRightClicked();
@@ -1465,19 +1413,13 @@ public class ResidencePlayerListener implements Listener {
 
         if (Flags.commandblock.isGlobalyEnabled() && entity instanceof CommandMinecart) {
             mainFlag = Flags.commandblock;
-            // ItemFrame covers item_frame/glow_item_frame
-        } else if (Flags.container.isGlobalyEnabled() && entity instanceof ItemFrame) {
+
+        } else if (Flags.container.isGlobalyEnabled() && Utils.isContainerEntityWithoutGui(entity)) {
             mainFlag = Flags.container;
             subFlag = Flags.use;
 
         } else if (Flags.leash.isGlobalyEnabled() && entity instanceof LeashHitch) {
             mainFlag = Flags.leash;
-
-        } else if (Flags.container.isGlobalyEnabled() && canHaveContainer(entity, player)) {
-            mainFlag = Flags.container;
-
-        } else if (Flags.riding.isGlobalyEnabled() && canRide(entity, player)) {
-            mainFlag = Flags.riding;
 
         } else if (Flags.trade.isGlobalyEnabled() && Utils.isVillagerOrTrader(entity)) {
             mainFlag = Flags.trade;
@@ -1508,20 +1450,17 @@ public class ResidencePlayerListener implements Listener {
         if (item == null) {
             return;
         }
+        // Check held Material Blacklist
+        if (!plugin.getItemManager().isAllowed(item.getType(), player) && !ResAdmin.isResAdmin(player)) {
+            lm.General_ItemBlacklisted.sendMessage(player);
+            event.setCancelled(true);
+            return;
+        }
         CMIMaterial held = CMIMaterial.get(item);
         Flags mainFlag;
         Flags subFlag = null;
 
-        if (entity instanceof ItemFrame) {
-            // Check held Material Blacklist
-            PermissionGroup group = plugin.getPlayerManager().getResidencePlayer(player).getGroup();
-            if (!plugin.getItemManager().isAllowed(item.getType(), group, entity.getWorld().getName()) && !ResAdmin.isResAdmin(player)) {
-                lm.General_ItemBlacklisted.sendMessage(player);
-                event.setCancelled(true);
-            }
-            return;
-
-        } else if (Flags.dye.isGlobalyEnabled() && entity instanceof Sheep && held.containsCriteria(CMIMC.DYE)) {
+        if (Flags.dye.isGlobalyEnabled() && entity instanceof Sheep && held.containsCriteria(CMIMC.DYE)) {
             mainFlag = Flags.dye;
             subFlag = Flags.animalkilling;
 
@@ -1581,6 +1520,46 @@ public class ResidencePlayerListener implements Listener {
             return;
         }
         if (FlagPermissions.shouldDenyAndNotify(player, event.getEntity(), Flags.shear, null)) {
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onEntityTryRideVehicle(VehicleEnterEvent event) {
+
+        Entity entity = event.getEntered();
+
+        if (entity instanceof Player) {
+            if (FlagPermissions.shouldIgnoreCheck(Flags.riding, entity)) {
+                return;
+            }
+            if (FlagPermissions.shouldDenyAndNotify((Player) entity, event.getVehicle(), Flags.riding, null)) {
+                event.setCancelled(true);
+            }
+        } else {
+            if (FlagPermissions.shouldIgnoreCheck(Flags.boarding, entity)) {
+                return;
+            }
+            if (FlagPermissions.has(entity.getLocation(), Flags.boarding, FlagCombo.OnlyFalse)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onPlayerOpenVehicleInventory(InventoryOpenEvent event) {
+
+        Player player = (Player) event.getPlayer();
+
+        if (FlagPermissions.shouldIgnoreCheck(Flags.container, player)) {
+            return;
+        }
+        InventoryHolder holder = event.getInventory().getHolder();
+
+        if (!(holder instanceof Vehicle)) {
+            return;
+        }
+        if (FlagPermissions.shouldDenyAndNotify(player, (Vehicle) holder, Flags.container, null)) {
             event.setCancelled(true);
         }
     }

--- a/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listeners/ResidencePlayerListener.java
@@ -1284,81 +1284,19 @@ public class ResidencePlayerListener implements Listener {
     }
 
     private boolean isContainer(Material mat) {
-        return FlagPermissions.getMaterialUseFlagList().containsKey(mat) && FlagPermissions.getMaterialUseFlagList().get(mat).equals(Flags.container)
+        return FlagPermissions.getMaterialUseFlagList().get(mat) == Flags.container
                 || plugin.getConfigManager().getCustomContainers().contains(mat);
     }
 
-    public static boolean isCanUseEntity_BothClick(Material mat) {
-        CMIMaterial cmat = CMIMaterial.get(mat);
-
-        switch (cmat) {
+    private boolean canBothClickBlock(Material mat) {
+        switch (CMIMaterial.get(mat)) {
         case NOTE_BLOCK:
         case DRAGON_EGG:
             return true;
         default:
-            return Residence.getInstance().getConfigManager().getCustomBothClick().contains(mat);
+            return plugin.getConfigManager().getCustomBothClick().contains(mat)
+                    || plugin.getConfigManager().getCustomContainers().contains(mat);
         }
-    }
-
-    private boolean isCanUseEntity_RClickOnly(Material mat) {
-        CMIMaterial cmat = CMIMaterial.get(mat);
-
-        switch (cmat) {
-        case ANVIL:
-        case BEACON:
-        case BELL:
-        case BREWING_STAND:
-        case CAMPFIRE:
-        case CARTOGRAPHY_TABLE:
-        case CHAIN_COMMAND_BLOCK:
-        case CHIPPED_ANVIL:
-        case COMMAND_BLOCK:
-        case COMPARATOR:
-        case CRAFTER:
-        case CRAFTING_TABLE:
-        case DAMAGED_ANVIL:
-        case DAYLIGHT_DETECTOR:
-        case ENCHANTING_TABLE:
-        case FLETCHING_TABLE:
-        case FLOWER_POT:
-        case GRINDSTONE:
-        case LECTERN:
-        case LEGACY_DIODE_BLOCK_OFF:
-        case LEGACY_DIODE_BLOCK_ON:
-        case LEGACY_REDSTONE_COMPARATOR_OFF:
-        case LEGACY_REDSTONE_COMPARATOR_ON:
-        case LEVER:
-        case LOOM:
-        case REPEATER:
-        case REPEATING_COMMAND_BLOCK:
-        case RESPAWN_ANCHOR:
-        case SMITHING_TABLE:
-        case SOUL_CAMPFIRE:
-        case STONECUTTER:
-            return true;
-        default:
-            break;
-        }
-
-        if (cmat.containsCriteria(CMIMC.BED)
-                || cmat.containsCriteria(CMIMC.BUTTON)
-                || cmat.containsCriteria(CMIMC.CAKE)
-                || cmat.containsCriteria(CMIMC.CANDLE)
-                || cmat.containsCriteria(CMIMC.CANDLECAKE)
-                || cmat.containsCriteria(CMIMC.DOOR)
-                || cmat.containsCriteria(CMIMC.FENCEGATE)
-                || cmat.containsCriteria(CMIMC.TRAPDOOR)
-                || cmat.containsCriteria(CMIMC.POTTED))
-            return true;
-
-        if (mat.name().equals("DAYLIGHT_DETECTOR_INVERTED"))
-            return true;
-
-        return plugin.getConfigManager().getCustomRightClick().contains(mat);
-    }
-
-    private boolean isCanUseEntity(Material mat) {
-        return isCanUseEntity_BothClick(mat) || isCanUseEntity_RClickOnly(mat);
     }
 
     @EventHandler(priority = EventPriority.LOWEST) // Do not use (ignoreCancelled = true)
@@ -1393,93 +1331,74 @@ public class ResidencePlayerListener implements Listener {
         if (event.useInteractedBlock() == Result.DENY) {
             return;
         }
-        Material mat = block.getType();
+        Material blockType = block.getType();
+        // Residence assigns Flags internally for Material
+        Flags flag = FlagPermissions.getMaterialUseFlagList().get(blockType);
 
-        if (!isContainer(mat) && !isCanUseEntity(mat))
-            return;
-
-        FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
-        boolean hasUse = perms.playerHas(player, Flags.use, true);
-
-        ClaimedResidence res = plugin.getResidenceManager().getByLoc(block.getLocation());
-        // Restrict defender container use in raid
-        if (res != null && res.getRaid().isUnderRaid() && res.getRaid().isDefender(player) && !ConfigManager.RaidDefenderContainerUsage) {
-            Flags result = FlagPermissions.getMaterialUseFlagList().get(mat);
-            if (result != null && result.equals(Flags.container)) {
-                event.setCancelled(true);
-                lm.Raid_cantDo.sendMessage(player);
-                return;
+        if (flag == null) {
+            // Custom right-click block check; Flags.use
+            if ((event.getAction() == Action.RIGHT_CLICK_BLOCK && plugin.getConfigManager().getCustomRightClick().contains(blockType))
+                    // Custom both-click block check; Flags.use
+                    || plugin.getConfigManager().getCustomBothClick().contains(blockType)) {
+                flag = Flags.use;
+                // Custom both-click container check; Flags.container
+            } else if (plugin.getConfigManager().getCustomContainers().contains(blockType)) {
+                flag = Flags.container;
             }
         }
-
-        if (res == null || !res.isOwner(player)) {
-
-            Flags result = FlagPermissions.getMaterialUseFlagList().get(mat);
-            // Residence assigns Flags internally for Material
-            if (result != null) {
-                // Start AbstractBlockClickFlag Check
-                main: if (!perms.playerHas(player, result, hasUse)) {
-
-                    if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-
-                        if (res != null && res.getRaid().isUnderRaid() && res.getRaid().isAttacker(player)) {
-                            break main;
-                        }
-
-                        switch (result) {
-                        case button:
-                            if (ResPerm.bypass_button.hasPermission(player, 10000L))
-                                break main;
-                            break;
-                        case container:
-                            if (ResPerm.bypass_container.hasPermission(player, 10000L))
-                                break main;
-                            break;
-                        case door:
-                            if (ResPerm.bypass_door.hasPermission(player, 10000L))
-                                break main;
-                            break;
-                        }
-                        event.setCancelled(true);
-                        lm.Flag_Deny.sendMessage(player, result);
-                        return;
-                    }
-
-                    if (isCanUseEntity_BothClick(mat)) {
-
-                        if (res != null && res.getRaid().isUnderRaid() && res.getRaid().isAttacker(player)) {
-                            break main;
-                        }
-                        event.setCancelled(true);
-                        lm.Flag_Deny.sendMessage(player, result);
-                    }
+        // Not Vanilla Raid
+        if (ConfigManager.RaidEnabled && flag != null) {
+            ClaimedResidence res = ClaimedResidence.getByLoc(block.getLocation());
+            if (res != null && res.getRaid().isUnderRaid()) {
+                // Exempt interaction check for Raid attacker
+                if (res.getRaid().isAttacker(player)) {
                     return;
                 }
-                // End AbstractBlockClickFlag Check
+                // Restrict defender container use in raid
+                if (!ConfigManager.RaidDefenderContainerUsage && flag == Flags.container && res.getRaid().isDefender(player)) {
+                    lm.Raid_cantDo.sendMessage(player);
+                    event.setCancelled(true);
+                    return;
+                }
             }
         }
-        // Restrict custom both-click container use
-        if (plugin.getConfigManager().getCustomContainers().contains(mat)) {
-            if (!perms.playerHas(player, Flags.container, hasUse)
-                    || !ResPerm.bypass_container.hasPermission(player, 10000L)) {
-                event.setCancelled(true);
-                lm.Flag_Deny.sendMessage(player, Flags.container);
-                return;
-            }
-        }
-        // Restrict custom both-click block
-        if (!hasUse && plugin.getConfigManager().getCustomBothClick().contains(mat)) {
-            event.setCancelled(true);
-            lm.Flag_Deny.sendMessage(player, Flags.use);
+        if (flag == null) {
             return;
         }
-        // Restrict custom right-click block
-        if (!hasUse && event.getAction() == Action.RIGHT_CLICK_BLOCK
-                && plugin.getConfigManager().getCustomRightClick().contains(mat)) {
-            event.setCancelled(true);
-            lm.Flag_Deny.sendMessage(player, Flags.use);
-        }
+        // Start AbstractBlockClickFlag Check
+        FlagPermissions perms = FlagPermissions.getPerms(block.getLocation(), player);
+        boolean hasUse = (flag == Flags.use) || perms.playerHas(player, Flags.use, true);
 
+        if (perms.playerHas(player, flag, hasUse)) {
+            return;
+        }
+        switch (flag) {
+        case button:
+            if (ResPerm.bypass_button.hasPermission(player, 10000L)) {
+                return;
+            }
+            break;
+        case container:
+            if (ResPerm.bypass_container.hasPermission(player, 10000L)) {
+                return;
+            }
+            break;
+        case door:
+            if (ResPerm.bypass_door.hasPermission(player, 10000L)) {
+                return;
+            }
+            break;
+        }
+        if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+            lm.Flag_Deny.sendMessage(player, flag);
+            event.setCancelled(true);
+            return;
+        }
+        if (canBothClickBlock(blockType)) {
+            lm.Flag_Deny.sendMessage(player, flag);
+            event.setCancelled(true);
+        }
+        // End AbstractBlockClickFlag Check
     }
 
     private boolean canHaveContainer(Entity entity, Player player) {
@@ -1512,13 +1431,13 @@ public class ResidencePlayerListener implements Listener {
         if (player.isSneaking()) {
             return false;
         }
-        if (!(entity instanceof Vehicle)) {
-            return false;
-        }
-        CMIEntityType type = CMIEntityType.get(entity);
-        if (type != null) {
-            // Non-rideable Vehicles
+        if (entity instanceof Vehicle) {
+            CMIEntityType type = CMIEntityType.get(entity);
+            if (type == null) {
+                return true;
+            }
             switch (type) {
+            // Non-rideable Vehicles
             case CHEST_MINECART:
             case COMMAND_BLOCK_MINECART:
             case FURNACE_MINECART:

--- a/src/main/java/com/bekvon/bukkit/residence/listenersCache/DenyMessageCache.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listenersCache/DenyMessageCache.java
@@ -21,7 +21,7 @@ public class DenyMessageCache {
     public static void reloadDenyMessageCache(int expireSeconds) {
         DENY_MESSAGE_CACHE = CacheBuilder.newBuilder()
                 .expireAfterWrite(expireSeconds, TimeUnit.SECONDS)
-                .maximumSize(1000)
+                .maximumSize(10_000)
                 .build();
     }
 

--- a/src/main/java/com/bekvon/bukkit/residence/listenersCache/DenyMessageCache.java
+++ b/src/main/java/com/bekvon/bukkit/residence/listenersCache/DenyMessageCache.java
@@ -11,25 +11,33 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /*
-Should be usable in 1.16.5+ versions
-For DenyMessage on high-frequency events
+Should be usable in 1.16+ versions
+Suppress frequent duplicate Flag-Deny messages
 */
 public class DenyMessageCache {
 
-    private static final Cache<DenyMessageKey, Boolean> DENY_MESSAGE_CACHE = CacheBuilder.newBuilder()
-            .expireAfterWrite(3, TimeUnit.SECONDS)
-            .maximumSize(1000)
-            .build();
+    private static Cache<DenyMessageKey, Boolean> DENY_MESSAGE_CACHE;
+
+    public static void reloadDenyMessageCache(int expireSeconds) {
+        DENY_MESSAGE_CACHE = CacheBuilder.newBuilder()
+                .expireAfterWrite(expireSeconds, TimeUnit.SECONDS)
+                .maximumSize(1000)
+                .build();
+    }
 
     private DenyMessageCache() {
     }
 
     public static boolean shouldSendDenyMessage(@NotNull Player player, @NotNull Flags flag) {
+        Cache<DenyMessageKey, Boolean> cache = DENY_MESSAGE_CACHE;
+        if (cache == null) {
+            return true;
+        }
         DenyMessageKey key = new DenyMessageKey(player, flag);
-        if (DENY_MESSAGE_CACHE.getIfPresent(key) != null) {
+        if (cache.getIfPresent(key) != null) {
             return false;
         }
-        DENY_MESSAGE_CACHE.put(key, true);
+        cache.put(key, true);
         return true;
     }
 

--- a/src/main/java/com/bekvon/bukkit/residence/protection/FlagPermissions.java
+++ b/src/main/java/com/bekvon/bukkit/residence/protection/FlagPermissions.java
@@ -21,12 +21,15 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import com.bekvon.bukkit.residence.Residence;
 import com.bekvon.bukkit.residence.containers.Flags;
 import com.bekvon.bukkit.residence.containers.MinimizeFlags;
+import com.bekvon.bukkit.residence.containers.ResAdmin;
 import com.bekvon.bukkit.residence.containers.ResidencePlayer;
 import com.bekvon.bukkit.residence.containers.lm;
 import com.bekvon.bukkit.residence.permissions.PermissionGroup;
@@ -1748,5 +1751,53 @@ public class FlagPermissions {
 
     public static void setIgnoreGroupedFlagsAccess(boolean flagsAccess) {
         ignoreGroupedFlagsAccess = flagsAccess;
+    }
+
+    public static boolean shouldIgnoreCheck(@NotNull Flags flag, @NotNull Block block) {
+        if (!flag.isGlobalyEnabled()) {
+            return true;
+        }
+        return Residence.getInstance().isDisabledWorldListener(block.getWorld());
+    }
+
+    public static boolean shouldIgnoreCheck(@NotNull Flags flag, @NotNull Entity entity) {
+        if (!flag.isGlobalyEnabled()) {
+            return true;
+        }
+        return Residence.getInstance().isDisabledWorldListener(entity.getWorld());
+    }
+
+    public static boolean shouldIgnoreCheck(@NotNull Flags flag, @NotNull World world) {
+        if (!flag.isGlobalyEnabled()) {
+            return true;
+        }
+        return Residence.getInstance().isDisabledWorldListener(world);
+    }
+
+    public static boolean shouldDenyAndNotify(@NotNull Player player, @NotNull Location target, @Nullable Flags mainFlag, @Nullable Flags subFlag) {
+        if (mainFlag == null) {
+            return false;
+        }
+        if (player.hasMetadata("NPC")) {
+            return false;
+        }
+        FlagPermissions perms = FlagPermissions.getPerms(target, player);
+        // if subFlag is not needed, please pass null
+        boolean result = (subFlag == null || perms.playerHas(player, subFlag, true));
+        // if mainFlag is in None state -> use subFlag result
+        if (perms.playerHas(player, mainFlag, result) || ResAdmin.isResAdmin(player)) {
+            return false;
+        }
+        // if mainFlag state is false, deny and notify the player
+        lm.Flag_Deny.sendMessage(player, mainFlag);
+        return true;
+    }
+
+    public static boolean shouldDenyAndNotify(@NotNull Player player, @NotNull Block target, @Nullable Flags mainFlag, @Nullable Flags subFlag) {
+        return shouldDenyAndNotify(player, target.getLocation(), mainFlag, subFlag);
+    }
+
+    public static boolean shouldDenyAndNotify(@NotNull Player player, @NotNull Entity target, @Nullable Flags mainFlag, @Nullable Flags subFlag) {
+        return shouldDenyAndNotify(player, target.getLocation(), mainFlag, subFlag);
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/protection/FlagPermissions.java
+++ b/src/main/java/com/bekvon/bukkit/residence/protection/FlagPermissions.java
@@ -1765,10 +1765,7 @@ public class FlagPermissions {
         return !flag.isGlobalyEnabled() || Residence.getInstance().isDisabledWorldListener(world);
     }
 
-    public static boolean shouldDenyAndNotify(@NotNull Player player, @NotNull Location target, @Nullable Flags mainFlag, @Nullable Flags subFlag) {
-        if (mainFlag == null) {
-            return false;
-        }
+    public static boolean shouldDenyAndNotify(@NotNull Player player, @NotNull Location target, @NotNull Flags mainFlag, @Nullable Flags subFlag) {
         if (player.hasMetadata("NPC")) {
             return false;
         }
@@ -1784,11 +1781,11 @@ public class FlagPermissions {
         return true;
     }
 
-    public static boolean shouldDenyAndNotify(@NotNull Player player, @NotNull Block target, @Nullable Flags mainFlag, @Nullable Flags subFlag) {
+    public static boolean shouldDenyAndNotify(@NotNull Player player, @NotNull Block target, @NotNull Flags mainFlag, @Nullable Flags subFlag) {
         return shouldDenyAndNotify(player, target.getLocation(), mainFlag, subFlag);
     }
 
-    public static boolean shouldDenyAndNotify(@NotNull Player player, @NotNull Entity target, @Nullable Flags mainFlag, @Nullable Flags subFlag) {
+    public static boolean shouldDenyAndNotify(@NotNull Player player, @NotNull Entity target, @NotNull Flags mainFlag, @Nullable Flags subFlag) {
         return shouldDenyAndNotify(player, target.getLocation(), mainFlag, subFlag);
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/protection/FlagPermissions.java
+++ b/src/main/java/com/bekvon/bukkit/residence/protection/FlagPermissions.java
@@ -1753,25 +1753,16 @@ public class FlagPermissions {
         ignoreGroupedFlagsAccess = flagsAccess;
     }
 
-    public static boolean shouldIgnoreCheck(@NotNull Flags flag, @NotNull Block block) {
-        if (!flag.isGlobalyEnabled()) {
-            return true;
-        }
-        return Residence.getInstance().isDisabledWorldListener(block.getWorld());
+    public static boolean shouldIgnoreCheck(@NotNull Flags flag, Block block) {
+        return !flag.isGlobalyEnabled() || Residence.getInstance().isDisabledWorldListener(block);
     }
 
-    public static boolean shouldIgnoreCheck(@NotNull Flags flag, @NotNull Entity entity) {
-        if (!flag.isGlobalyEnabled()) {
-            return true;
-        }
-        return Residence.getInstance().isDisabledWorldListener(entity.getWorld());
+    public static boolean shouldIgnoreCheck(@NotNull Flags flag, Entity entity) {
+        return !flag.isGlobalyEnabled() || Residence.getInstance().isDisabledWorldListener(entity);
     }
 
-    public static boolean shouldIgnoreCheck(@NotNull Flags flag, @NotNull World world) {
-        if (!flag.isGlobalyEnabled()) {
-            return true;
-        }
-        return Residence.getInstance().isDisabledWorldListener(world);
+    public static boolean shouldIgnoreCheck(@NotNull Flags flag, World world) {
+        return !flag.isGlobalyEnabled() || Residence.getInstance().isDisabledWorldListener(world);
     }
 
     public static boolean shouldDenyAndNotify(@NotNull Player player, @NotNull Location target, @Nullable Flags mainFlag, @Nullable Flags subFlag) {

--- a/src/main/java/com/bekvon/bukkit/residence/selection/VisualizerConfig.java
+++ b/src/main/java/com/bekvon/bukkit/residence/selection/VisualizerConfig.java
@@ -34,7 +34,7 @@ public class VisualizerConfig {
     private static boolean bounceAnimation;
     private static boolean enterAnimation;
 
-    private static volatile boolean useModernVersion = true;
+    private static boolean useModernVersion = true;
     private static int gridSize = 8;
     private static int updateRateByTravel = 4;
     private static double lineThickness = 0.05;

--- a/src/main/java/com/bekvon/bukkit/residence/selection/VisualizerConfig.java
+++ b/src/main/java/com/bekvon/bukkit/residence/selection/VisualizerConfig.java
@@ -34,7 +34,7 @@ public class VisualizerConfig {
     private static boolean bounceAnimation;
     private static boolean enterAnimation;
 
-    private static boolean useModernVersion = true;
+    private static volatile boolean useModernVersion = true;
     private static int gridSize = 8;
     private static int updateRateByTravel = 4;
     private static double lineThickness = 0.05;
@@ -47,6 +47,9 @@ public class VisualizerConfig {
         if (Version.isCurrentEqualOrHigher(Version.v1_19_4)) {
             c.addComment("Global.Visualizer.Type", "Which type of visualization we should use. Particle or Modern.");
             setUseModernVersion(c.get("Global.Visualizer.Type", "Modern").equalsIgnoreCase("Modern"));
+            if (!isUseModernVersion()) {
+                CuboidDisplayManager.removeAllPlayerDisplays();
+            }
         } else {
             setUseModernVersion(false);
         }

--- a/src/main/java/com/bekvon/bukkit/residence/selectionVisuals/CuboidDisplayManager.java
+++ b/src/main/java/com/bekvon/bukkit/residence/selectionVisuals/CuboidDisplayManager.java
@@ -130,8 +130,21 @@ public class CuboidDisplayManager implements Listener {
         data.displays.clear();
     }
 
+    public static void removeAllPlayerDisplays() {
+        for (PlayerData data : players.values()) {
+            for (CuboidDisplay display : data.displays) {
+                display.clear();
+            }
+            data.displays.clear();
+        }
+        players.clear();
+    }
+
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent event) {
+        if (!VisualizerConfig.isUseModernVersion()) {
+            return;
+        }
         Location from = event.getFrom();
         Location to = event.getTo();
 
@@ -165,6 +178,9 @@ public class CuboidDisplayManager implements Listener {
 
     @EventHandler
     public void onPlayerTeleport(PlayerTeleportEvent event) {
+        if (!VisualizerConfig.isUseModernVersion()) {
+            return;
+        }
         Player player = event.getPlayer();
         PlayerData data = players.get(player.getUniqueId());
 
@@ -188,6 +204,9 @@ public class CuboidDisplayManager implements Listener {
 
     @EventHandler
     public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
+        if (!VisualizerConfig.isUseModernVersion()) {
+            return;
+        }
         Player player = event.getPlayer();
         PlayerData data = players.get(player.getUniqueId());
 
@@ -201,6 +220,9 @@ public class CuboidDisplayManager implements Listener {
 
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
+        if (!VisualizerConfig.isUseModernVersion()) {
+            return;
+        }
         removeAll(event.getPlayer());
     }
 

--- a/src/main/java/com/bekvon/bukkit/residence/shopStuff/ShopListener.java
+++ b/src/main/java/com/bekvon/bukkit/residence/shopStuff/ShopListener.java
@@ -34,7 +34,7 @@ public class ShopListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onSignInteract(PlayerInteractEvent event) {
         // disabling event on world
-        if (plugin.isDisabledWorldListener(event.getPlayer().getWorld()))
+        if (plugin.isDisabledWorldListener(event.getPlayer()))
             return;
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK)
             return;

--- a/src/main/java/com/bekvon/bukkit/residence/utils/Utils.java
+++ b/src/main/java/com/bekvon/bukkit/residence/utils/Utils.java
@@ -1,6 +1,7 @@
 package com.bekvon.bukkit.residence.utils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -15,16 +16,18 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Animals;
 import org.bukkit.entity.Bat;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.IronGolem;
 import org.bukkit.entity.NPC;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.entity.Snowman;
+import org.bukkit.entity.Tameable;
 import org.bukkit.entity.Vehicle;
+import org.bukkit.entity.Villager;
 import org.bukkit.entity.WaterMob;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.util.BlockIterator;
@@ -296,37 +299,44 @@ public class Utils {
         return false;
     }
 
-    public static boolean isArmorStandEntity(EntityType ent) {
-        if (Version.isCurrentEqualOrLower(Version.v1_7_R4))
-            return false;
-        return ent == org.bukkit.entity.EntityType.ARMOR_STAND;
+    public static boolean isTamed(Entity entity) {
+        return entity instanceof Tameable && ((Tameable) entity).isTamed();
+    }
+
+    public static boolean isVillagerOrTrader(Entity entity) {
+        if (Version.isCurrentEqualOrHigher(Version.v1_14_0)) {
+            return entity instanceof org.bukkit.entity.AbstractVillager;
+        }
+        return entity instanceof Villager;
+    }
+
+    public static boolean isPhantom(Entity entity) {
+        return Version.isCurrentEqualOrHigher(Version.v1_13_0) && entity instanceof org.bukkit.entity.Phantom;
+    }
+
+    public static boolean isArmorStand(Entity entity) {
+        return Version.isCurrentEqualOrHigher(Version.v1_8_0) && entity instanceof org.bukkit.entity.ArmorStand;
     }
 
     public static boolean isSpectator(org.bukkit.GameMode mode) {
-        if (Version.isCurrentEqualOrLower(Version.v1_7_R4))
-            return false;
-        return mode == org.bukkit.GameMode.SPECTATOR;
+        return Version.isCurrentEqualOrHigher(Version.v1_8_0) && mode == org.bukkit.GameMode.SPECTATOR;
     }
 
     public static boolean isMainHand(PlayerInteractEvent event) {
-        if (Version.isCurrentEqualOrLower(Version.v1_8_R3))
-            return true;
-        return event.getHand() == EquipmentSlot.HAND ? true : false;
+        if (Version.isCurrentEqualOrHigher(Version.v1_9_0)) {
+            return event.getHand() == EquipmentSlot.HAND;
+        }
+        return true;
     }
 
-    public static boolean isChorusTeleport(org.bukkit.event.player.PlayerTeleportEvent.TeleportCause tpcause) {
-        if (Version.isCurrentEqualOrLower(Version.v1_8_R3))
-            return false;
-        return tpcause == org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT;
+    public static boolean isChorusTeleport(TeleportCause tpcause) {
+        return Version.isCurrentEqualOrHigher(Version.v1_9_0) && tpcause == TeleportCause.CHORUS_FRUIT;
     }
 
     public static List<Block> getPistonRetractBlocks(BlockPistonRetractEvent event) {
-        List<Block> blocks = new ArrayList<Block>();
-        if (Version.isCurrentEqualOrLower(Version.v1_7_R4)) {
-            blocks.add(event.getBlock());
-        } else {
-            blocks.addAll(event.getBlocks());
+        if (Version.isCurrentEqualOrHigher(Version.v1_8_0)) {
+            return event.getBlocks();
         }
-        return blocks;
+        return Collections.singletonList(event.getBlock());
     }
 }

--- a/src/main/java/com/bekvon/bukkit/residence/utils/Utils.java
+++ b/src/main/java/com/bekvon/bukkit/residence/utils/Utils.java
@@ -17,6 +17,7 @@ import org.bukkit.entity.Animals;
 import org.bukkit.entity.Bat;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.IronGolem;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.NPC;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -25,6 +26,7 @@ import org.bukkit.entity.Tameable;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.WaterMob;
+import org.bukkit.entity.minecart.PoweredMinecart;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -327,6 +329,12 @@ public class Utils {
             return event.getHand() == EquipmentSlot.HAND;
         }
         return true;
+    }
+
+    public static boolean isContainerEntityWithoutGui(Entity entity) {
+        return  entity instanceof ItemFrame
+                || entity instanceof PoweredMinecart
+                || (Version.isCurrentEqualOrHigher(Version.v1_19_0) && entity instanceof org.bukkit.entity.Allay);
     }
 
     public static boolean isChorusTeleport(TeleportCause tpcause) {

--- a/src/main/resources/flags.yml
+++ b/src/main/resources/flags.yml
@@ -112,7 +112,7 @@ Global:
     # Allow or deny creeper explosions
     creeper: true
     # Applies to: Residence
-    # Allows or denys all entity damage within the residence
+    # Allow or deny damage to players and tamed animals
     damage: false
     # Applies to: Residence
     # Sets day time in residence

--- a/src/main/resources/flags.yml
+++ b/src/main/resources/flags.yml
@@ -345,7 +345,7 @@ Global:
     # Applies to: Both
     # Allows or denys sheep shear
     shear: true
-    # Applies to: Residence
+    # Applies to: Both
     # Allows or denys shooting projectile in area
     shoot: true
     # Applies to: Residence

--- a/src/main/resources/flags.yml
+++ b/src/main/resources/flags.yml
@@ -262,6 +262,9 @@ Global:
     # Allows or denys players to use looms
     loom: true
     # Applies to: Residence
+    # Allow or deny derailed hopper minecarts from sucking items from containers
+    minecartsuction: true
+    # Applies to: Residence
     # Prevents mob droping exp on death
     mobexpdrop: true
     # Applies to: Residence

--- a/src/main/resources/flags.yml
+++ b/src/main/resources/flags.yml
@@ -516,6 +516,7 @@ Global:
     leash: LEAD
     lever: LEVER
     loom: LOOM
+    minecartsuction: HOPPER_MINECART
     mobexpdrop: MELON_SEEDS
     mobgriefing: BONE
     mobitemdrop: COCOA_BEANS

--- a/src/main/resources/flags.yml
+++ b/src/main/resources/flags.yml
@@ -709,8 +709,8 @@ ItemList:
     # this is the actual list of material names that this list allows or disallows
     # You can look up the material name by item ID in game by typing /res material <id>
     # Alternativly, you can simply use the item ID in the list, but its less descriptive and harder to see what the list allows or dissallows at a glance
-    Items:
-    - LAVA
-    - WATER
-    - STATIONARY_LAVA
-    - STATIONARY_WATER
+    # Items:
+    # - Apple
+    # - Stone
+    # - Lava_Bucket
+    Items: []


### PR DESCRIPTION
**Main changes:**

**1. Flags.shoot is now FlagMode.Both**
(Fine-grained control over player projectile shooting)

**2. Fix SulfurCubeBucket bypass protection**

**3. Apply Flags.windexplode to (Wind Burst enchantment) and (Wind-Charged effect)**
(We use ExplosionResult.TRIGGER_BLOCK to cover all forms of Wind Explode, since the Potion of Wind Charging allows any living entity to become an explosion source)

**4. Fix fire_charge bypassing protection to ignite TNT**

**5. Add cooldown option for sending duplicate Flag deny messages(v1.16+)**
(Effectively suppresses frequent duplicate Flag-Deny messages; players don't need to receive 20 identical denial messages within a single second)

**6. Add option HopperCrossResidenceCheck**
(This protection now supports all versions)

**7. Add Flags.minecartsuction**
(Allow or deny derailed hopper minecarts from sucking items from containers)
(Prevent trolls from pushing derailed hopper minecarts into the Residence to steal items from containers)
https://github.com/Zrips/Residence/commit/6e300779daeae06365d4cf4f27cc1624d1331a13
https://github.com/Zrips/Residence/issues/185
(Bring back this feature and make it toggleable via flag)

_Minor changes:_

_Clear player displays on config reload;_
_(Exempt some checks early when Visualizer.Type.Modern is not in use)_

_Notify player when knockback is denied, e.g., for wind charge explosion knockback rejection._

_Name tag checks are only for LivingEntity – right‑click does nothing on non‑living entities(Armor stands are still LivingEntity)_

_Reuse and simplify many repetitive checks_

_Apply Flags.animalgriefing/mobgriefing to more places_

_Fix CustomContainers/CustomBothClick/CustomRightClick not clearing the original material list on config reload_

_Vehicle container opening check now works on all supported versions_

_Flags.boarding now supports all non-player entities and all versions_

_ItemBlacklist now checks entity and air interactions, and when damaging entities_